### PR TITLE
Add reporter entrypoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.13
+    rev: v0.1.14
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
@@ -29,6 +29,6 @@ repos:
       args: [-c, pyproject.toml]
       additional_dependencies: ["bandit[toml]"]
   - repo: https://github.com/jsh9/pydoclint
-    rev: 0.3.8
+    rev: 0.3.9
     hooks:
       - id: pydoclint

--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -1,6 +1,6 @@
 """A framework for organizing and running benchmark workloads on machine learning models."""
 
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, entry_points, version
 
 try:
     __version__ = version("nnbench")
@@ -10,5 +10,20 @@ except PackageNotFoundError:
 
 # TODO: This naming is unfortunate
 from .core import benchmark, parametrize
-from .reporter import BaseReporter
+from .reporter import BaseReporter, register_reporter
 from .types import Benchmark, Params
+
+
+def add_reporters():
+    eps = entry_points()
+
+    if hasattr(eps, "select"):  # Python 3.10+ / importlib.metadata >= 3.9.0
+        reporters = eps.select(group="nnbench.reporters")
+    else:
+        reporters = eps.get("nnbench.reporters", [])  # type: ignore
+
+    for rep in reporters:
+        register_reporter(rep.name)
+
+
+add_reporters()

--- a/src/nnbench/reporter.py
+++ b/src/nnbench/reporter.py
@@ -2,6 +2,7 @@
 A lightweight interface for refining, displaying, and streaming benchmark results to various sinks.
 """
 
+import importlib
 import sys
 import types
 from typing import Any
@@ -58,3 +59,19 @@ _reporter_registry: dict[str, type[BaseReporter]] = {
 reporter_registry: types.MappingProxyType[str, type[BaseReporter]] = types.MappingProxyType(
     _reporter_registry
 )
+
+
+def register_reporter(name: str) -> None:
+    """
+    Register a reporter class by its fully qualified module path.
+
+    Parameters
+    ----------
+    name: str
+        The full module path to the reporter class. For example, when registering a class
+        ``MyReporter`` located in ``my_module``, ``name`` should be ``my_module.MyReporter``.
+    """
+    modname, clsname = name.rsplit(".", 1)
+    mod = importlib.import_module(modname)
+    cls = getattr(mod, clsname)
+    _reporter_registry[name] = cls


### PR DESCRIPTION
Adds a function that registers custom reporters via an importlib entry point. 

Such entry points can be added in setup.py or pyproject.toml, each via a top-level keyword.