### PR TITLE
Refactor context values to be dicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ ignore = [
 
 [tool.bandit]
 exclude_dirs = ["tests"]
+skips = ["B101"]
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -1,20 +1,19 @@
 """Utilities for collecting context key-value pairs as metadata in benchmark runs."""
 
 import platform
-from typing import Any, Callable, Sequence, Union
+from typing import Any, Callable
 
-ContextTuple = tuple[str, Any]
-ContextProvider = Callable[[], Union[ContextTuple, Sequence[ContextTuple]]]
-"""A function providing a context value. Context tuple is structured as context key name and value."""
-
-
-def system() -> tuple[str, str]:
-    return "system", platform.system()
+ContextProvider = Callable[[], dict[str, Any]]
+"""A function providing a dictionary of context values."""
 
 
-def cpuarch() -> tuple[str, str]:
-    return "cpuarch", platform.machine()
+def system() -> dict[str, str]:
+    return {"system": platform.system()}
 
 
-def python_version() -> tuple[str, str]:
-    return "python_version", platform.python_version()
+def cpuarch() -> dict[str, str]:
+    return {"cpuarch": platform.machine()}
+
+
+def python_version() -> dict[str, str]:
+    return {"python_version": platform.python_version()}


### PR DESCRIPTION
The resulting context building/collection code is much easier than with tuples, where you have to do lengthy type checks.

The existing context providers have been changed to return length-1 dictionaries.

B101 has been disabled globally, since it is a nuisance and most people do not compile to bytecode, anyway.