### PR TITLE
Add cartesian product decorator for benchmarks

### DIFF
--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -9,7 +9,7 @@ except PackageNotFoundError:
     pass
 
 # TODO: This naming is unfortunate
-from .core import benchmark, parametrize
+from .core import benchmark, parametrize, product
 from .reporter import BaseReporter, register_reporter
 from .types import Benchmark, Params
 


### PR DESCRIPTION
Adds the third core decorator for parametrizing benchmarks, which is the cartesian product of variable collections. It is exposed as `nnbench.product`.

Compared to the "inner product" approach of `nnbench.parametrize`, which consumes an iterable of dictionaries, this decorator consumes a keyworded collection of iterables, which it then binds to the benchmark function. This results in an "outer product" with a number of benchmarks that is equal to the products of the numbers of values in each iterable.

However, since `functools.partial` binds parameters lazily, users do not immediately get feedback on whether they supplied the correct argument names in the iterable variable keyword arguments. This needs to be improved, by either implementing a check inside the decorator or by typing it to the decorated benchmark function's param spec (Python 3.11+).

Closes #5.