### PR TITLE
Handle untyped interfaces in `_check`

### DIFF
--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -23,6 +23,10 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
     for bm in benchmarks:
         for name, param in inspect.signature(bm.fn).parameters.items():
             param_type = param.annotation
+
+            if param.annotation == inspect.Parameter.empty:
+                logger.warn(f"Warning: Parameter {name!r} in benchmark {bm.fn.__name__} is untyped.")
+
             if name in benchmark_interface and benchmark_interface[name].annotation != param_type:
                 orig_type = benchmark_interface[name].annotation
                 raise TypeError(

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -29,7 +29,7 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
 
             param_type = param.annotation
 
-            if param.annotation == inspect.Parameter.empty:
+            if param_type == inspect.Parameter.empty:
                 logger.debug(f"Found untyped parameter {name!r} in benchmark {bm.fn.__name__!r}.")
 
             if name in benchmark_interface and benchmark_interface[name].annotation != param_type:

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -29,8 +29,8 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
                     f"Warning: Parameter {name!r} in benchmark '{bm.fn.__name__}' is untyped."
                 )
 
-            if name in benchmark_interface and benchmark_interface[name].annotation != param_type:
-                orig_type = benchmark_interface[name].annotation
+            orig_type = benchmark_interface[name].annotation
+            if name in benchmark_interface and orig_type != param_type:
                 raise TypeError(
                     f"got non-unique types {orig_type}, {param_type} for parameter {name!r}"
                 )

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -25,7 +25,9 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
             param_type = param.annotation
 
             if param.annotation == inspect.Parameter.empty:
-                logger.warn(f"Warning: Parameter {name!r} in benchmark {bm.fn.__name__} is untyped.")
+                logger.warn(
+                    f"Warning: Parameter {name!r} in benchmark '{bm.fn.__name__}' is untyped."
+                )
 
             if name in benchmark_interface and benchmark_interface[name].annotation != param_type:
                 orig_type = benchmark_interface[name].annotation
@@ -36,7 +38,9 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
     for name, param in benchmark_interface.items():
         if name not in param_types and param.default == inspect.Parameter.empty:
             raise ValueError(f"missing value for required parameter {name!r}")
-        if not issubclass(param_types[name], param.annotation):
+        if not param.annotation == inspect.Parameter.empty and not issubclass(
+            param_types[name], param.annotation
+        ):  # only check type match if type supplied
             raise TypeError(
                 f"expected type {param.annotation} for parameter {name!r}, "
                 f"got {param_types[name]!r}"

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -25,9 +25,7 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
             param_type = param.annotation
 
             if param.annotation == inspect.Parameter.empty:
-                logger.debug(
-                    f"Found untyped parameter {name!r} in benchmark {bm.fn.__name__!r}."
-                )
+                logger.debug(f"Found untyped parameter {name!r} in benchmark {bm.fn.__name__!r}.")
 
             if name in benchmark_interface and benchmark_interface[name].annotation != param_type:
                 orig_type = benchmark_interface[name].annotation
@@ -40,11 +38,11 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
         if name not in param_types and param.default == inspect.Parameter.empty:
             raise ValueError(f"missing value for required parameter {name!r}")
 
-        if not param.annotation == inspect.Parameter.empty:
+        if param.annotation == inspect.Parameter.empty:
             continue
 
         # only check type match if type supplied
-        if issubclass(param_types[name], param.annotation):
+        if not issubclass(param_types[name], param.annotation):
             raise TypeError(
                 f"expected type {param.annotation} for parameter {name!r}, "
                 f"got {param_types[name]!r}"

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -29,8 +29,8 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
                     f"Found untyped parameter {name!r} in benchmark {bm.fn.__name__!r}."
                 )
 
-            orig_type = benchmark_interface[name].annotation
-            if name in benchmark_interface and orig_type != param_type:
+            if name in benchmark_interface and benchmark_interface[name].annotation != param_type:
+                orig_type = benchmark_interface[name].annotation
                 raise TypeError(
                     f"got non-unique types {orig_type}, {param_type} for parameter {name!r}"
                 )

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -25,8 +25,8 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
             param_type = param.annotation
 
             if param.annotation == inspect.Parameter.empty:
-                logger.warn(
-                    f"Warning: Parameter {name!r} in benchmark '{bm.fn.__name__}' is untyped."
+                logger.debug(
+                    f"Found untyped parameter {name!r} in benchmark {bm.fn.__name__!r}."
                 )
 
             orig_type = benchmark_interface[name].annotation
@@ -35,12 +35,16 @@ def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
                     f"got non-unique types {orig_type}, {param_type} for parameter {name!r}"
                 )
             benchmark_interface[name] = param
+
     for name, param in benchmark_interface.items():
         if name not in param_types and param.default == inspect.Parameter.empty:
             raise ValueError(f"missing value for required parameter {name!r}")
-        if not param.annotation == inspect.Parameter.empty and not issubclass(
-            param_types[name], param.annotation
-        ):  # only check type match if type supplied
+
+        if not param.annotation == inspect.Parameter.empty:
+            continue
+
+        # only check type match if type supplied
+        if issubclass(param_types[name], param.annotation):
             raise TypeError(
                 f"expected type {param.annotation} for parameter {name!r}, "
                 f"got {param_types[name]!r}"

--- a/tests/test_argcheck.py
+++ b/tests/test_argcheck.py
@@ -22,3 +22,10 @@ def test_error_on_duplicate_params(typecheckfolder: str) -> None:
     with pytest.raises(TypeError, match="got non-unique types.*"):
         r = runner.AbstractBenchmarkRunner()
         r.run(benchmarks, params={"x": 1, "y": 1})
+
+
+def test_untyped_interface(typecheckfolder: str) -> None:
+    benchmarks = os.path.join(typecheckfolder, "untyped_benchmarks.py")
+
+    r = runner.AbstractBenchmarkRunner()
+    r.run(benchmarks, params={"value": 2})

--- a/tests/typechecking/untyped_benchmarks.py
+++ b/tests/typechecking/untyped_benchmarks.py
@@ -1,0 +1,6 @@
+import nnbench
+
+
+@nnbench.benchmark
+def increment(value):
+    return value + 1


### PR DESCRIPTION
Guard match checks of types in function signature and supplied via the `params` kwarg in the `benchmark` decorators `_check` method against untyped function signatures. 

If untyped, we do not check for matching types. We also log a warning to the `stdout` of the `logger` indicating the untyped parameter and function name. 