### PR TITLE
Add interface class member to Benchmark class

### DIFF
--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -108,6 +108,23 @@ class Benchmark:
 
 @dataclass(frozen=True)
 class Interface:
+    """
+    Data model representing a function's interface. An instance of this class
+    is created using the `from_callable` class method.
+
+    Parameters:
+    ----------
+    names : tuple[str, ...]
+        Names of the function parameters.
+    types : tuple[type, ...]
+        Types of the function parameters.
+    variables : tuple[Variable, ...]
+        A tuple of tuples, where each inner tuple contains the parameter name and type.
+    defaults : dict[str, Any]
+        A dictionary mapping the parameters names to default values.
+        Only contains parameters with default values.
+    """
+
     names: tuple[str, ...]
     types: tuple[type, ...]
     variables: tuple[Variable, ...]
@@ -115,6 +132,9 @@ class Interface:
 
     @classmethod
     def from_callable(cls, fn: Callable) -> Interface:
+        """
+        Creates an Interface instance from a given callable.
+        """
         sig = inspect.signature(fn)
         return cls(
             tuple(sig.parameters.keys()),

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import inspect
 import os
 from dataclasses import dataclass, field
-from typing import Any, Callable, Generic, TypedDict, TypeVar
+from typing import Any, Callable, Generic, TypedDict, TypeVar, Tuple, Dict
 
 T = TypeVar("T")
 
@@ -97,12 +97,17 @@ class Benchmark:
     @dataclass(frozen=True)
     class Interface:
         fn: Callable[..., Any]
+        varnames: Tuple[str, ...] | None = field(default=None)
+        vartypes: Tuple[inspect.Parameter, ...] | None = field(default=None)
+        varitems: Tuple[Tuple[str, inspect.Parameter], ...] | None = field(
+            default=None)
+        defaults: Dict[str, Any] | None = field(default=None)
 
         def __post_init__(self) -> None:
             sig = inspect.signature(self.fn)
             super().__setattr__("varnames", tuple(sig.parameters.keys()))
             super().__setattr__("vartypes", tuple(sig.parameters.values()))
-            super().__setattr__("varitems", tuple(sig.parameters.values()))
+            super().__setattr__("varitems", tuple(sig.parameters.items()))
             super().__setattr__("defaults", {n: p.default for n, p in sig.parameters.items()})
 
     def __post_init__(self):

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -87,6 +87,8 @@ class Benchmark:
         A teardown hook run after the benchmark. Must take all members of `params` as inputs.
     tags: tuple[str, ...]
         Additional tags to attach for bookkeeping and selective filtering during runs.
+    interface: Interface
+        Interface of the benchmark function
     """
 
     fn: Callable[..., Any]
@@ -94,6 +96,7 @@ class Benchmark:
     setUp: Callable[..., None] = field(repr=False, default=NoOp)
     tearDown: Callable[..., None] = field(repr=False, default=NoOp)
     tags: tuple[str, ...] = field(repr=False, default=())
+    interface: Interface = field(init=False, repr=False)
 
     def __post_init__(self):
         if not self.name:

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import inspect
 import os
 from dataclasses import dataclass, field
-from typing import Any, Callable, Generic, TypedDict, TypeVar, Tuple, Dict
+from typing import Any, Callable, Dict, Generic, Tuple, TypedDict, TypeVar
 
 T = TypeVar("T")
 
@@ -99,8 +99,7 @@ class Benchmark:
         fn: Callable[..., Any]
         varnames: Tuple[str, ...] | None = field(default=None)
         vartypes: Tuple[inspect.Parameter, ...] | None = field(default=None)
-        varitems: Tuple[Tuple[str, inspect.Parameter], ...] | None = field(
-            default=None)
+        varitems: Tuple[Tuple[str, inspect.Parameter], ...] | None = field(default=None)
         defaults: Dict[str, Any] | None = field(default=None)
 
         def __post_init__(self) -> None:

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Generic, TypedDict, TypeVar
 
 T = TypeVar("T")
+Variable = tuple[str, type]
 
 
 class BenchmarkResult(TypedDict):
@@ -104,9 +105,9 @@ class Benchmark:
 
 @dataclass(frozen=True)
 class Interface:
-    varnames: tuple[str, ...]
-    vartypes: tuple[type, ...]
-    varitems: tuple[tuple[str, inspect.Parameter], ...]
+    names: tuple[str, ...]
+    types: tuple[type, ...]
+    variables: tuple[Variable, ...]
     defaults: dict[str, Any]
 
     @classmethod
@@ -115,6 +116,6 @@ class Interface:
         return cls(
             tuple(sig.parameters.keys()),
             tuple(p.annotation for p in sig.parameters.values()),
-            tuple(sig.parameters.items()),
+            tuple((k, v.annotation) for k, v in sig.parameters.items()),
             {n: p.default for n, p in sig.parameters.items()},
         )

--- a/tests/test_benchmark_cls.py
+++ b/tests/test_benchmark_cls.py
@@ -1,13 +1,13 @@
 import inspect
 
-import nnbench
+from nnbench import types
 
 
 def test_interface_with_no_arguments():
     def empty_function() -> None:
         pass
 
-    interface = nnbench.Benchmark.Interface(empty_function)
+    interface = types.Interface.from_callable(empty_function)
     assert interface.varnames == ()
     assert interface.vartypes == ()
     assert interface.varitems == ()
@@ -18,9 +18,9 @@ def test_interface_with_multiple_arguments():
     def complex_function(a: int, b, c: str = "hello", d: float = 10.0) -> None:  # type:ignore
         pass
 
-    interface = nnbench.Benchmark.Interface(complex_function)
+    interface = types.Interface.from_callable(complex_function)
     assert interface.varnames == ("a", "b", "c", "d")
-    assert tuple(param.annotation for param in interface.vartypes) == (
+    assert interface.vartypes == (
         int,
         inspect._empty,
         str,

--- a/tests/test_benchmark_cls.py
+++ b/tests/test_benchmark_cls.py
@@ -1,4 +1,5 @@
 import inspect
+
 import nnbench
 
 
@@ -20,14 +21,12 @@ def test_interface_with_multiple_arguments():
     interface = nnbench.Benchmark.Interface(complex_function)
     assert interface.varnames == ("a", "b", "c", "d")
     assert tuple(param.annotation for param in interface.vartypes) == (
-        int, inspect._empty, str, float)
+        int,
+        inspect._empty,
+        str,
+        float,
+    )
 
     varitems = [(param.name, param.annotation) for name, param in interface.varitems]
-    assert varitems == [
-        ("a", int),
-        ("b", inspect._empty),
-        ("c", str),
-        ("d", float)
-    ]
-    assert interface.defaults == {
-        'a': inspect._empty, 'b': inspect._empty, 'c': 'hello', 'd': 10.0}
+    assert varitems == [("a", int), ("b", inspect._empty), ("c", str), ("d", float)]
+    assert interface.defaults == {"a": inspect._empty, "b": inspect._empty, "c": "hello", "d": 10.0}

--- a/tests/test_benchmark_cls.py
+++ b/tests/test_benchmark_cls.py
@@ -8,9 +8,9 @@ def test_interface_with_no_arguments():
         pass
 
     interface = types.Interface.from_callable(empty_function)
-    assert interface.varnames == ()
-    assert interface.vartypes == ()
-    assert interface.varitems == ()
+    assert interface.names == ()
+    assert interface.types == ()
+    assert interface.variables == ()
     assert interface.defaults == {}
 
 
@@ -19,14 +19,13 @@ def test_interface_with_multiple_arguments():
         pass
 
     interface = types.Interface.from_callable(complex_function)
-    assert interface.varnames == ("a", "b", "c", "d")
-    assert interface.vartypes == (
+    assert interface.names == ("a", "b", "c", "d")
+    assert interface.types == (
         int,
         inspect._empty,
         str,
         float,
     )
 
-    varitems = [(param.name, param.annotation) for name, param in interface.varitems]
-    assert varitems == [("a", int), ("b", inspect._empty), ("c", str), ("d", float)]
+    assert interface.variables == (("a", int), ("b", inspect._empty), ("c", str), ("d", float))
     assert interface.defaults == {"a": inspect._empty, "b": inspect._empty, "c": "hello", "d": 10.0}

--- a/tests/test_benchmark_cls.py
+++ b/tests/test_benchmark_cls.py
@@ -1,0 +1,33 @@
+import inspect
+import nnbench
+
+
+def test_interface_with_no_arguments():
+    def empty_function() -> None:
+        pass
+
+    interface = nnbench.Benchmark.Interface(empty_function)
+    assert interface.varnames == ()
+    assert interface.vartypes == ()
+    assert interface.varitems == ()
+    assert interface.defaults == {}
+
+
+def test_interface_with_multiple_arguments():
+    def complex_function(a: int, b, c: str = "hello", d: float = 10.0) -> None:  # type:ignore
+        pass
+
+    interface = nnbench.Benchmark.Interface(complex_function)
+    assert interface.varnames == ("a", "b", "c", "d")
+    assert tuple(param.annotation for param in interface.vartypes) == (
+        int, inspect._empty, str, float)
+
+    varitems = [(param.name, param.annotation) for name, param in interface.varitems]
+    assert varitems == [
+        ("a", int),
+        ("b", inspect._empty),
+        ("c", str),
+        ("d", float)
+    ]
+    assert interface.defaults == {
+        'a': inspect._empty, 'b': inspect._empty, 'c': 'hello', 'd': 10.0}


### PR DESCRIPTION
Add an `Interface` immutable dataclass to the `Benchmark` class that contains the signature information of a function. I.e.: 

- Keys
- Values
- Key - Value Pairs 
- Defaults