### PR TITLE
Refactor and improve combined interface check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.6
+    rev: 1.7.7
     hooks:
     - id: bandit
       args: [-c, pyproject.toml]

--- a/tests/test_argcheck.py
+++ b/tests/test_argcheck.py
@@ -20,7 +20,7 @@ def test_argcheck(typecheckfolder: str) -> None:
 def test_error_on_duplicate_params(typecheckfolder: str) -> None:
     benchmarks = os.path.join(typecheckfolder, "duplicate_benchmarks.py")
 
-    with pytest.raises(TypeError, match="got non-unique types.*"):
+    with pytest.raises(TypeError, match="got incompatible types.*"):
         r = runner.AbstractBenchmarkRunner()
         r.run(benchmarks, params={"x": 1, "y": 1})
 
@@ -32,7 +32,7 @@ def test_log_warn_on_overwrite_default(
     r = runner.AbstractBenchmarkRunner()
     with caplog.at_level(logging.DEBUG):
         r.run(benchmark, params={"a": 1})
-    assert "using value 1 instead of default" in caplog.text
+    assert "using given value 1 over default value" in caplog.text
 
 
 def test_untyped_interface(typecheckfolder: str) -> None:

--- a/tests/test_benchmark_cls.py
+++ b/tests/test_benchmark_cls.py
@@ -4,28 +4,30 @@ from nnbench import types
 
 
 def test_interface_with_no_arguments():
-    def empty_function() -> None:
+    def fn() -> None:
         pass
 
-    interface = types.Interface.from_callable(empty_function)
+    interface = types.Interface.from_callable(fn)
     assert interface.names == ()
     assert interface.types == ()
+    assert interface.defaults == ()
     assert interface.variables == ()
-    assert interface.defaults == {}
+    assert interface.returntype is type(None)
 
 
 def test_interface_with_multiple_arguments():
-    def complex_function(a: int, b, c: str = "hello", d: float = 10.0) -> None:  # type:ignore
+    def fn(a: int, b, c: str = "hello", d: float = 10.0) -> None:  # type: ignore
         pass
 
-    interface = types.Interface.from_callable(complex_function)
+    interface = types.Interface.from_callable(fn)
+    empty = inspect.Parameter.empty
     assert interface.names == ("a", "b", "c", "d")
-    assert interface.types == (
-        int,
-        inspect._empty,
-        str,
-        float,
+    assert interface.types == (int, empty, str, float)
+    assert interface.defaults == (empty, empty, "hello", 10.0)
+    assert interface.variables == (
+        ("a", int, empty),
+        ("b", empty, empty),
+        ("c", str, "hello"),
+        ("d", float, 10.0),
     )
-
-    assert interface.variables == (("a", int), ("b", inspect._empty), ("c", str), ("d", float))
-    assert interface.defaults == {"a": inspect._empty, "b": inspect._empty, "c": "hello", "d": 10.0}
+    assert interface.returntype is type(None)


### PR DESCRIPTION
Uses the newly defined benchmark function's interface everywhere.

Fixes a type check which would fail if a variable has two non-identical types in two different benchmarks, but which are compatible (i.e. one is a subtype of the other).

Also fixes an error where a missing default parameter in one benchmark could be overridden by a present one in another benchmark. Now, a missing default value means a missing default in the resulting union interface.