### PR TITLE
Rename `AbstractBenchmarkRunner->BenchmarkRunner`

### DIFF
--- a/src/nnbench/core.py
+++ b/src/nnbench/core.py
@@ -66,7 +66,7 @@ def benchmark(
 
     The resulting benchmark can either be completely (i.e., the resulting function takes no
     more arguments) or incompletely parametrized. In the latter case, the remaining free
-    parameters need to be passed in the calls to `AbstractBenchmarkRunner.run()`.
+    parameters need to be passed in the calls to `BenchmarkRunner.run()`.
 
     Parameters
     ----------
@@ -139,7 +139,7 @@ def parametrize(
 
     The resulting benchmarks can either be completely (i.e., the resulting function takes no
     more arguments) or incompletely parametrized. In the latter case, the remaining free
-    parameters need to be passed in the call to `AbstractBenchmarkRunner.run()`.
+    parameters need to be passed in the call to `BenchmarkRunner.run()`.
 
     Parameters
     ----------
@@ -223,7 +223,7 @@ def product(
 
     The resulting benchmarks can either be completely (i.e., the resulting function takes no
     more arguments) or incompletely parametrized. In the latter case, the remaining free
-    parameters need to be passed in the call to `AbstractBenchmarkRunner.run()`.
+    parameters need to be passed in the call to `BenchmarkRunner.run()`.
 
     Parameters
     ----------

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -80,7 +80,7 @@ def isdunder(s: str) -> bool:
     return s.startswith("__") and s.endswith("__")
 
 
-class AbstractBenchmarkRunner:
+class BenchmarkRunner:
     """An abstract benchmark runner class."""
 
     benchmark_type = Benchmark

--- a/tests/test_argcheck.py
+++ b/tests/test_argcheck.py
@@ -8,7 +8,7 @@ from nnbench import runner
 
 def test_argcheck(testfolder: str) -> None:
     benchmarks = os.path.join(testfolder, "standard_benchmarks.py")
-    r = runner.AbstractBenchmarkRunner()
+    r = runner.BenchmarkRunner()
     with pytest.raises(TypeError, match="expected type <class 'int'>.*"):
         r.run(benchmarks, params={"x": 1, "y": "1"}, tags=("standard",))
     with pytest.raises(ValueError, match="missing value for required parameter.*"):
@@ -21,13 +21,13 @@ def test_error_on_duplicate_params(testfolder: str) -> None:
     benchmarks = os.path.join(testfolder, "argument_check_benchmarks.py")
 
     with pytest.raises(TypeError, match="got incompatible types.*"):
-        r = runner.AbstractBenchmarkRunner()
+        r = runner.BenchmarkRunner()
         r.run(benchmarks, params={"x": 1, "y": 1}, tags=("duplicate",))
 
 
 def test_log_warn_on_overwrite_default(testfolder: str, caplog: pytest.LogCaptureFixture) -> None:
     benchmark = os.path.join(testfolder, "argument_check_benchmarks.py")
-    r = runner.AbstractBenchmarkRunner()
+    r = runner.BenchmarkRunner()
     with caplog.at_level(logging.DEBUG):
         r.run(benchmark, params={"a": 1}, tags=("with_default",))
     assert "using given value 1 over default value" in caplog.text
@@ -36,5 +36,5 @@ def test_log_warn_on_overwrite_default(testfolder: str, caplog: pytest.LogCaptur
 def test_untyped_interface(testfolder: str) -> None:
     benchmarks = os.path.join(testfolder, "argument_check_benchmarks.py")
 
-    r = runner.AbstractBenchmarkRunner()
+    r = runner.BenchmarkRunner()
     r.run(benchmarks, params={"value": 2}, tags=("untyped",))

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,10 +1,10 @@
 import os
 
-from nnbench.runner import AbstractBenchmarkRunner
+from nnbench.runner import BenchmarkRunner
 
 
 def test_runner_discovery(testfolder: str) -> None:
-    r = AbstractBenchmarkRunner()
+    r = BenchmarkRunner()
 
     r.collect(os.path.join(testfolder, "standard_benchmarks.py"), tags=("runner-collect",))
     assert len(r.benchmarks) == 1


### PR DESCRIPTION
Better name to present in examples and documentation.