### PR TITLE
Fix tag check in collection

### DIFF
--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -92,9 +92,7 @@ class BenchmarkRunner:
         """Clear all registered benchmarks."""
         self.benchmarks.clear()
 
-    def collect(
-        self, path_or_module: str | os.PathLike[str] = "__main__", tags: tuple[str, ...] = ()
-    ) -> None:
+    def collect(self, path_or_module: str | os.PathLike[str], tags: tuple[str, ...] = ()) -> None:
         # TODO: functools.cache this guy
         """
         Discover benchmarks in a module and memoize them for later use.
@@ -136,14 +134,13 @@ class BenchmarkRunner:
             if isdunder(k):
                 continue
             elif isinstance(v, self.benchmark_type):
-                self.benchmarks.append(v)
+                if not tags or set(tags) & set(v.tags):
+                    self.benchmarks.append(v)
             elif iscontainer(v):
                 for bm in v:
                     if isinstance(bm, self.benchmark_type):
-                        self.benchmarks.append(bm)
-
-        # and finally, filter by tags.
-        self.benchmarks = [b for b in self.benchmarks if set(tags) <= set(b.tags)]
+                        if not tags or set(tags) & set(bm.tags):
+                            self.benchmarks.append(bm)
 
     def run(
         self,

--- a/tests/test_benchmarks/tag_selection_benchmark.py
+++ b/tests/test_benchmarks/tag_selection_benchmark.py
@@ -1,0 +1,16 @@
+import nnbench
+
+
+@nnbench.benchmark(tags=("tag1",))
+def subtract(a: int, b: int) -> int:
+    return a - b
+
+
+@nnbench.benchmark(tags=("tag1", "tag2"))
+def decrement(a: int) -> int:
+    return a - 1
+
+
+@nnbench.benchmark()
+def identity(x: int) -> int:
+    return x

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -13,3 +13,21 @@ def test_runner_discovery(testfolder: str) -> None:
 
     r.collect(testfolder, tags=("runner-collect",))
     assert len(r.benchmarks) == 1
+
+
+def test_tag_selection(testfolder: str) -> None:
+    PATH = os.path.join(testfolder, "tag_selection_benchmark.py")
+
+    r = BenchmarkRunner()
+
+    r.collect(PATH, tags=())
+    assert len(r.benchmarks) == 3
+    r.clear()
+
+    r.collect(PATH, tags=("tag1",))
+    assert len(r.benchmarks) == 2
+    r.clear()
+
+    r.collect(PATH, tags=("tag2",))
+    assert len(r.benchmarks) == 1
+    r.clear()


### PR DESCRIPTION
Remove default argument of BenchmarkRunner.collect() to match defaultless run(). Use tag set intersection for selection.