### PR TITLE
Check type of parametrized argument to avoid mismatch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.14
+    rev: v0.2.0
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,8 @@ ignore_missing_imports = true
 # explicitly set src folder for isort to understand first-party imports correctly.
 src = ["src"]
 line-length = 100
+
+[tool.ruff.lint]
 # Enable pycodestyle errors & warnings (`E`, `W`), Pyflakes (`F`), and isort (`I`) by default.
 select = ["E", "F", "I", "W"]
 ignore = [
@@ -99,7 +101,7 @@ ignore = [
     "F841",
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Ignore unused imports in all `__init__.py` files
 "__init__.py" = ["F401"]
 


### PR DESCRIPTION
Newer test coverage has reminded us that we check argnames only, not argtypes in parameters of `@nnbench.parametrize` and `@nnbench.product`.

To fix, we grab the expected types from the signature and optionally unwrap them in the appropriate manner if they are generics or union types.