### PR TITLE
Add more default information to benchmark JSON result

### DIFF
--- a/src/nnbench/core.py
+++ b/src/nnbench/core.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import inspect
 import itertools
+import sys
 import types
 import warnings
 from functools import partial, update_wrapper
-from typing import Any, Callable, Iterable, get_args, get_origin, overload
+from typing import Any, Callable, Iterable, Union, get_args, get_origin, overload
 
 from nnbench.types import Benchmark
 
@@ -32,12 +33,13 @@ def _check_against_interface(params: dict[str, Any], fun: Callable) -> None:
         # to unwrap generic containers like list[str].
         expected_type = get_origin(fvtype) or fvtype
         # in case of a union like str | int, check args instead.
-        if expected_type is types.UnionType:
+        union_type = Union if sys.version_info < (3, 10) else types.UnionType
+        if expected_type is union_type:
             expected_type = get_args(fvtype)
         if not isinstance(v, expected_type):
             raise TypeError(
-                f"expected type {fvtype}, got type {type(v)} "
-                f"for parametrized argument {k!r} of benchmark {fun.__name__}()"
+                f"benchmark {fun.__name__}(): expected type {fvtype}, "
+                f"got type {type(v)} for parametrized argument {k!r}"
             )
 
 

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -1,94 +1,23 @@
 """The abstract benchmark runner interface, which can be overridden for custom benchmark workloads."""
 from __future__ import annotations
 
+import contextlib
 import inspect
 import logging
 import os
 import sys
+import time
 import warnings
 from dataclasses import asdict
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Sequence, get_origin
+from typing import Any, Generator, Sequence, get_origin
 
 from nnbench.context import ContextProvider
 from nnbench.types import Benchmark, BenchmarkRecord, Parameters
 from nnbench.util import import_file_as_module, ismodule
 
 logger = logging.getLogger(__name__)
-
-
-def _check(params: dict[str, Any], benchmarks: list[Benchmark]) -> None:
-    param_types = {k: type(v) for k, v in params.items()}
-    allvars: dict[str, tuple[type, Any]] = {}
-    empty = inspect.Parameter.empty
-
-    def _issubtype(t1: type, t2: type) -> bool:
-        """Small helper to make typechecks work on generics."""
-
-        def _canonicalize(t: type) -> type:
-            t_origin = get_origin(t)
-            if t_origin is not None:
-                return t_origin
-            return t
-
-        if t1 == t2:
-            return True
-
-        t1 = _canonicalize(t1)
-        t2 = _canonicalize(t2)
-        if not inspect.isclass(t1):
-            return False
-        # TODO: Extend typing checks to args.
-        return issubclass(t1, t2)
-
-    for bm in benchmarks:
-        for var in bm.interface.variables:
-            name, typ, default = var
-            if name in params and default != empty:
-                logger.debug(
-                    f"using given value {params[name]} over default value {default} "
-                    f"for parameter {name!r} in benchmark {bm.fn.__name__}()"
-                )
-
-            if typ == empty:
-                logger.debug(f"parameter {name!r} untyped in benchmark {bm.fn.__name__}().")
-
-            if name in allvars:
-                currvar = allvars[name]
-                orig_type, orig_val = new_type, new_val = currvar
-                # If a benchmark has a variable without a default value,
-                # that variable is taken into the combined interface as no-default.
-                if default == empty:
-                    new_val = default
-                # These types need not be exact matches, just compatible.
-                # Two types are compatible iff either is a subtype of the other.
-                # We only log the narrowest type for each varname in the final interface,
-                # since that determines whether an input value is admissible.
-                if _issubtype(orig_type, typ):
-                    pass
-                elif _issubtype(typ, orig_type):
-                    new_type = typ
-                else:
-                    raise TypeError(
-                        f"got incompatible types {orig_type}, {typ} for parameter {name!r}"
-                    )
-                newvar = (new_type, new_val)
-                if newvar != currvar:
-                    allvars[name] = newvar
-            else:
-                allvars[name] = (typ, default)
-
-    for name, (typ, default) in allvars.items():
-        # check if a no-default variable has no parameter.
-        if name not in param_types and default == empty:
-            raise ValueError(f"missing value for required parameter {name!r}")
-
-        # skip the subsequent type check if the variable is untyped.
-        if typ == empty:
-            continue
-        # type-check parameter value against the narrowest hinted type.
-        if name in param_types and not _issubtype(param_types[name], typ):
-            raise TypeError(f"expected type {typ} for parameter {name!r}, got {param_types[name]}")
 
 
 def iscontainer(s: Any) -> bool:
@@ -99,6 +28,16 @@ def isdunder(s: str) -> bool:
     return s.startswith("__") and s.endswith("__")
 
 
+@contextlib.contextmanager
+def timer(bm: dict[str, Any]) -> Generator[None, None, None]:
+    start = time.perf_counter_ns()
+    try:
+        yield
+    finally:
+        end = time.perf_counter_ns()
+        bm["time_ns"] = end - start
+
+
 class BenchmarkRunner:
     """An abstract benchmark runner class."""
 
@@ -106,6 +45,81 @@ class BenchmarkRunner:
 
     def __init__(self):
         self.benchmarks: list[Benchmark] = list()
+
+    def _check(self, params: dict[str, Any]) -> None:
+        param_types = {k: type(v) for k, v in params.items()}
+        allvars: dict[str, tuple[type, Any]] = {}
+        empty = inspect.Parameter.empty
+
+        def _issubtype(t1: type, t2: type) -> bool:
+            """Small helper to make typechecks work on generics."""
+
+            def _canonicalize(t: type) -> type:
+                t_origin = get_origin(t)
+                if t_origin is not None:
+                    return t_origin
+                return t
+
+            if t1 == t2:
+                return True
+
+            t1 = _canonicalize(t1)
+            t2 = _canonicalize(t2)
+            if not inspect.isclass(t1):
+                return False
+            # TODO: Extend typing checks to args.
+            return issubclass(t1, t2)
+
+        for bm in self.benchmarks:
+            for var in bm.interface.variables:
+                name, typ, default = var
+                if name in params and default != empty:
+                    logger.debug(
+                        f"using given value {params[name]} over default value {default} "
+                        f"for parameter {name!r} in benchmark {bm.fn.__name__}()"
+                    )
+
+                if typ == empty:
+                    logger.debug(f"parameter {name!r} untyped in benchmark {bm.fn.__name__}().")
+
+                if name in allvars:
+                    currvar = allvars[name]
+                    orig_type, orig_val = new_type, new_val = currvar
+                    # If a benchmark has a variable without a default value,
+                    # that variable is taken into the combined interface as no-default.
+                    if default == empty:
+                        new_val = default
+                    # These types need not be exact matches, just compatible.
+                    # Two types are compatible iff either is a subtype of the other.
+                    # We only log the narrowest type for each varname in the final interface,
+                    # since that determines whether an input value is admissible.
+                    if _issubtype(orig_type, typ):
+                        pass
+                    elif _issubtype(typ, orig_type):
+                        new_type = typ
+                    else:
+                        raise TypeError(
+                            f"got incompatible types {orig_type}, {typ} for parameter {name!r}"
+                        )
+                    newvar = (new_type, new_val)
+                    if newvar != currvar:
+                        allvars[name] = newvar
+                else:
+                    allvars[name] = (typ, default)
+
+        for name, (typ, default) in allvars.items():
+            # check if a no-default variable has no parameter.
+            if name not in param_types and default == empty:
+                raise ValueError(f"missing value for required parameter {name!r}")
+
+            # skip the subsequent type check if the variable is untyped.
+            if typ == empty:
+                continue
+            # type-check parameter value against the narrowest hinted type.
+            if name in param_types and not _issubtype(param_types[name], typ):
+                raise TypeError(
+                    f"expected type {typ} for parameter {name!r}, got {param_types[name]}"
+                )
 
     def clear(self) -> None:
         """Clear all registered benchmarks."""
@@ -164,7 +178,7 @@ class BenchmarkRunner:
     def run(
         self,
         path_or_module: str | os.PathLike[str],
-        params: dict[str, Any] | Parameters,
+        params: dict[str, Any] | Parameters | None = None,
         tags: tuple[str, ...] = (),
         context: Sequence[ContextProvider] = (),
     ) -> BenchmarkRecord:
@@ -176,7 +190,7 @@ class BenchmarkRunner:
         path_or_module: str | os.PathLike[str]
             Name or path of the module to discover benchmarks in. Can also be a directory,
             in which case benchmarks are collected from the Python files therein.
-        params: dict[str, Any] | Parameters
+        params: dict[str, Any] | Parameters | None
             Parameters to use for the benchmark run. Names have to match positional and keyword
             argument names of the benchmark functions.
         tags: tuple[str, ...]
@@ -197,7 +211,7 @@ class BenchmarkRunner:
         Raises
         ------
         ValueError
-            If any context key-value pair is provided more than once.
+            If any context value is provided more than once.
         """
         if not self.benchmarks:
             self.collect(path_or_module, tags)
@@ -207,12 +221,13 @@ class BenchmarkRunner:
             warnings.warn(f"No benchmarks found in path/module {str(path_or_module)!r}.")
             return BenchmarkRecord(context={}, benchmarks=[])
 
+        params = params or {}
         if isinstance(params, Parameters):
             dparams = asdict(params)
         else:
             dparams = params
 
-        _check(dparams, self.benchmarks)
+        self._check(dparams)
 
         ctx: dict[str, Any] = dict()
         ctxkeys = set(ctx.keys())
@@ -231,14 +246,20 @@ class BenchmarkRunner:
         results: list[dict[str, Any]] = []
         for benchmark in self.benchmarks:
             bmparams = {k: v for k, v in dparams.items() if k in benchmark.interface.names}
-            res: dict[str, Any] = {}
+            # TODO: Wrap this into an execution context
+            res: dict[str, Any] = {
+                "name": benchmark.name,
+                "function": f"{benchmark.fn.__qualname__}.{benchmark.fn.__name__}",
+                "description": benchmark.fn.__doc__,
+                "date": datetime.now().isoformat(timespec="seconds"),
+                "error_occurred": False,
+                "error_message": "",
+            }
             try:
                 benchmark.setUp(**bmparams)
-                # Todo: check params
-                res["name"] = benchmark.name
-                res["value"] = benchmark.fn(**bmparams)
+                with timer(res):
+                    res["value"] = benchmark.fn(**bmparams)
             except Exception as e:
-                # TODO: This needs work
                 res["error_occurred"] = True
                 res["error_message"] = str(e)
             finally:


### PR DESCRIPTION
Pads the resulting benchmark JSON document with a bit more information, like start date, elapsed wall time (in nanoseconds), function name, and description.

Also adds `error_occurred` and `error_message` to the JSON doc to stabilize the schema.

Part of #56.

Also makes a type comparison in the parametrize/product interface check compatible with Python < 3.10.