### PR TITLE
Final docs changes in preparation for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nnbench: A small framework for benchmarking machine learning models
 
 Welcome to nnbench, a framework for benchmarking machine learning models.
-The main goals of this project are:
+The main goals of this project are
 
 1. To provide a portable, easy-to-use solution for model evaluation that leads to better ML experiment organization, and
 2. To integrate with experiment and metadata tracking solutions for easy adoption.
@@ -10,7 +10,7 @@ On a high level, you can think of nnbench as "pytest for ML models" - you define
 
 What's new is that upon completion, you can stream the resulting data to any sink of your choice (including multiple at the same), which allows easy integration with experiment trackers and metadata stores.
 
-See the `quickstart.md` for usage examples.
+See the [quickstart](https://aai-institute.github.io/nnbench/latest/quickstart/) for a lightning-quick demo, or the [examples](https://aai-institute.github.io/nnbench/latest/tutorials/) for more advanced usages.
 
 ## Installation
 
@@ -19,13 +19,10 @@ See the `quickstart.md` for usage examples.
 Install it directly from source, for example either using `pip` or `poetry`:
 
 ```shell
-pip install git+https://github.com/aai-institute/nnbench.git
+pip install nnbench
 # or
-poetry add git+https://github.com/aai-institute/nnbench.git
+poetry add nnbench
 ```
-
-A PyPI package release is planned for the future.
-
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
     { name = "Adrian Rumpold", email = "a.rumpold@appliedai-institute.de" },
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 3 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Links to the quickstart and examples in the readme, since those are great places to start for new users.

Also changes the pip install instruction to the non-git standard PyPI workflow, because we now have the package pushed.