### PR TITLE
Group context structs under top-level semantic keys

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python and dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: pip
@@ -33,7 +33,7 @@ jobs:
           pip install -r requirements-dev.txt
           pip install -e . --no-deps
       - name: Cache pre-commit tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.MYPY_CACHE_DIR }}
@@ -52,7 +52,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up oldest supported Python on ${{ matrix.os }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Run tests on oldest supported Python
@@ -65,7 +65,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python and dependencies
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11
         cache: pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,10 +32,11 @@ jobs:
         run: |
           python -m build
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
+          if-no-files-found: error
       - name: Publish stable documentation for nnbench
         uses: ./.github/actions/mike-docs
         with:
@@ -49,7 +50,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/src/nnbench/reporter.py
+++ b/src/nnbench/reporter.py
@@ -3,11 +3,43 @@ A lightweight interface for refining, displaying, and streaming benchmark result
 """
 from __future__ import annotations
 
+import copy
 import importlib
+import re
 import sys
 import types
+from typing import Any
 
 from nnbench.types import BenchmarkRecord
+
+
+def nullcols(_benchmarks: list[dict[str, Any]]) -> set[str]:
+    nulls = set()
+    for i, bm in enumerate(_benchmarks):
+        bm_nulls = set(k for k, v in bm.items() if not v)
+
+        if i == 0:
+            # NB: This breaks if the schema is unstable.
+            nulls = bm_nulls
+        else:
+            # intersection to drop nulls that are populated in later benchmarks.
+            nulls &= bm_nulls
+    return nulls
+
+
+def nested_getitem(obj: dict[str, Any], item: str) -> Any:
+    items = item.split(".")
+    for n, it in enumerate(items):
+        try:
+            obj = obj[it]
+        except KeyError:
+            if n == 0:
+                msg = f"context has no member {item!r}"
+            else:
+                val = ".".join(items[: n + 1])
+                msg = f"nested context value {val!r} has no member {it!r}"
+            raise KeyError(msg) from None
+    return obj
 
 
 # TODO: Add IO mixins for database, file, and HTTP IO
@@ -38,18 +70,46 @@ class BenchmarkReporter:
 
 
 class ConsoleReporter(BenchmarkReporter):
-    # TODO: Implement regex filters, context values, display options, ... (__init__)
-    def report_result(self, record: BenchmarkRecord) -> None:
+    def __init__(self, tablefmt: str = "simple"):
+        self.tablefmt = tablefmt
+
+    def report_result(
+        self,
+        record: BenchmarkRecord,
+        benchmark_filter: str | None = None,
+        include_context: tuple[str, ...] = (),
+        exclude_empty: bool = True,
+    ) -> None:
         try:
             from tabulate import tabulate
         except ModuleNotFoundError:
             raise ValueError(
-                f"{self.__class__.__name__} requires `tabulate` to be installed. "
+                f"class {self.__class__.__name__}() requires `tabulate` to be installed. "
                 f"To install, run `{sys.executable} -m pip install --upgrade tabulate`."
             )
 
-        benchmarks = record["benchmarks"]
-        print(tabulate(benchmarks, headers="keys"))
+        ctx, benchmarks = record["context"], record["benchmarks"]
+
+        nulls = set() if not exclude_empty else nullcols(benchmarks)
+
+        if benchmark_filter is not None:
+            regex = re.compile(benchmark_filter, flags=re.IGNORECASE)
+        else:
+            regex = None
+
+        filtered = []
+        for bm in benchmarks:
+            if regex is not None and regex.search(bm["name"]) is None:
+                continue
+            bm_new = copy.copy(bm)
+            filteredctx = {k: nested_getitem(ctx, k) for k in include_context}
+            bm_new.update(filteredctx)
+            for nc in nulls:
+                bm_new.pop(nc)
+            filtered.append(bm_new)
+
+        # TODO: Add support for custom formatters
+        print(tabulate(filtered, headers="keys", tablefmt=self.tablefmt))
 
 
 # internal, mutable

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,35 +1,41 @@
-from nnbench.context import CPUInfo, GitEnvironmentInfo, PythonPackageInfo
+from nnbench.context import CPUInfo, GitEnvironmentInfo, PythonInfo
 
 
 def test_python_package_info() -> None:
-    p = PythonPackageInfo("pre-commit", "pyyaml")()
+    p = PythonInfo("pre-commit", "pyyaml")()
+    res = p["python"]
 
-    for v in p.values():
+    deps = res["dependencies"]
+    for v in deps.values():
         assert v != ""
 
     # for a bogus package, it should not fail but produce an empty string.
-    p = PythonPackageInfo("asdfghjkl")()
+    p = PythonInfo("asdfghjkl")()
+    res = p["python"]
 
-    for v in p.values():
+    deps = res["dependencies"]
+    for v in deps.values():
         assert v == ""
 
 
 def test_git_info_provider() -> None:
     g = GitEnvironmentInfo()()
+    res = g["git"]
     # tag might not be available in a shallow checkout in CI,
     # but commit, provider and repo are.
-    assert g["commit"] != ""
-    assert g["provider"] == "github.com"
-    assert g["repository"] == "aai-institute/nnbench"
+    assert res["commit"] != ""
+    assert res["provider"] == "github.com"
+    assert res["repository"] == "aai-institute/nnbench"
 
 
 def test_cpu_info_provider() -> None:
     c = CPUInfo()()
+    res = c["cpu"]
 
     # just check that the most important fields are populated across
     # the popular CPU architectures.
-    assert c["architecture"] != ""
-    assert c["system"] != ""
-    assert c["frequency"] > 0
-    assert c["num_cpus"] > 0
-    assert c["total_memory"] > 0
+    assert res["architecture"] != ""
+    assert res["system"] != ""
+    assert res["frequency"] > 0
+    assert res["num_cpus"] > 0
+    assert res["total_memory"] > 0


### PR DESCRIPTION
Instead of sticking the single keys into the top-level context struct, we group them under semantic keys in a lower nested level. This has the benefit that ambiguous keys like "version" or "commit" can be given for multiple context aspects, like Python vs. git vs. ...

Changes the unit tests to operate on the nested structs instead.