### PR TITLE
Fix runner collection by checking file path first

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
@@ -29,6 +29,6 @@ repos:
       args: [-c, pyproject.toml]
       additional_dependencies: ["bandit[toml]"]
   - repo: https://github.com/jsh9/pydoclint
-    rev: 0.3.9
+    rev: 0.4.0
     hooks:
       - id: pydoclint

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -75,7 +75,7 @@ from nnbench.reporter import ConsoleReporter
 r = nnbench.BenchmarkRunner()
 reporter = ConsoleReporter()
 
-result = r.run("./benchmarks.py", params={"n_estimators": 100, "max_depth": 5, "random_state": 42})
+result = r.run("benchmarks.py", params={"n_estimators": 100, "max_depth": 5, "random_state": 42})
 reporter.report(result)
 ```
 
@@ -127,7 +127,7 @@ from nnbench.reporter import ConsoleReporter
 r = nnbench.BenchmarkRunner()
 reporter = ConsoleReporter()
 
-result = r.run("./benchmarks.py", params={"random_state": 42})
+result = r.run("benchmarks.py", params={"random_state": 42})
 reporter.report(result)
 ```
 

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -144,23 +144,22 @@ class BenchmarkRunner:
         ValueError
             If the given path is not a Python file, directory, or module name.
         """
-        if ismodule(path_or_module):
+        ppath = Path(path_or_module)
+        if ppath.is_dir():
+            pythonpaths = (p for p in ppath.iterdir() if p.suffix == ".py")
+            for py in pythonpaths:
+                logger.debug(f"Collecting benchmarks from submodule {py.name!r}.")
+                self.collect(py, tags)
+            return
+        elif ppath.is_file():
+            module = import_file_as_module(path_or_module)
+        elif ismodule(path_or_module):
             module = sys.modules[str(path_or_module)]
         else:
-            ppath = Path(path_or_module)
-            if ppath.is_dir():
-                pythonpaths = (p for p in ppath.iterdir() if p.suffix == ".py")
-                for py in pythonpaths:
-                    logger.debug(f"Collecting benchmarks from submodule {py.name!r}.")
-                    self.collect(py, tags)
-                return
-            elif ppath.is_file():
-                module = import_file_as_module(path_or_module)
-            else:
-                raise ValueError(
-                    f"expected a module name, Python file, or directory, "
-                    f"got {str(path_or_module)!r}"
-                )
+            raise ValueError(
+                f"expected a module name, Python file, or directory, "
+                f"got {str(path_or_module)!r}"
+            )
 
         # iterate through the module dict members to register
         for k, v in module.__dict__.items():


### PR DESCRIPTION
This eliminates the previous failure case of trying to load a filepath with importlib.

By reordering, we incur more time for the module branch (i.e. if the input is a module name), but this is okay since the checks are cheap.

Fixes #69.