### PR TITLE
Improve file drivers, add dict roundtrip methods to `BenchmarkRecord`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.2.2
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
@@ -29,6 +29,6 @@ repos:
       args: [-c, pyproject.toml]
       additional_dependencies: ["bandit[toml]"]
   - repo: https://github.com/jsh9/pydoclint
-    rev: 0.4.0
+    rev: 0.4.1
     hooks:
       - id: pydoclint

--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -1,6 +1,6 @@
 """A framework for organizing and running benchmark workloads on machine learning models."""
 
-from importlib.metadata import PackageNotFoundError, entry_points, version
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("nnbench")
@@ -9,22 +9,6 @@ except PackageNotFoundError:
     pass
 
 from .core import benchmark, parametrize, product
-from .reporter import BenchmarkReporter, register_reporter
+from .reporter import BenchmarkReporter
 from .runner import BenchmarkRunner
 from .types import Parameters
-
-
-def add_reporters():
-    eps = entry_points()
-
-    if hasattr(eps, "select"):  # Python 3.10+ / importlib.metadata >= 3.9.0
-        reporters = eps.select(group="nnbench.reporters")
-    else:
-        reporters = eps.get("nnbench.reporters", [])  # type: ignore
-
-    for rep in reporters:
-        key, clsname = rep.name.split("=", 1)
-        register_reporter(key, clsname)
-
-
-add_reporters()

--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -189,10 +189,14 @@ class CPUInfo:
 
 class Context:
     def __init__(self, data: dict[str, Any] | None = None) -> None:
-        self._ctx_dict: dict[str, Any] = data or {}
+        self._data: dict[str, Any] = data or {}
 
     def __contains__(self, key: str) -> bool:
         return key in self.keys()
+
+    @property
+    def data(self):
+        return self._data
 
     @staticmethod
     def _ctx_items(d: dict[str, Any], prefix: str, sep: str) -> Iterator[tuple[str, Any]]:
@@ -234,7 +238,7 @@ class Context:
         str
             Iterator over the context dictionary keys.
         """
-        for k, v in self._ctx_items(d=self._ctx_dict, prefix="", sep=sep):
+        for k, v in self._ctx_items(d=self._data, prefix="", sep=sep):
             yield k
 
     def values(self) -> Iterator[Any]:
@@ -246,7 +250,7 @@ class Context:
         Any
             Iterator over all values in the context dictionary.
         """
-        for k, v in self._ctx_items(d=self._ctx_dict, prefix="", sep=""):
+        for k, v in self._ctx_items(d=self._data, prefix="", sep=""):
             yield v
 
     def items(self, sep: str = ".") -> Iterator[tuple[str, Any]]:
@@ -263,7 +267,7 @@ class Context:
         tuple[str, Any]
             Iterator over the items of the context dictionary.
         """
-        yield from self._ctx_items(d=self._ctx_dict, prefix="", sep=sep)
+        yield from self._ctx_items(d=self._data, prefix="", sep=sep)
 
     def update(self, other: ContextProvider | dict[str, Any] | "Context") -> None:
         """
@@ -278,8 +282,8 @@ class Context:
         if callable(other):
             other = other()
         elif isinstance(other, Context):
-            other = other._ctx_dict
-        self._ctx_dict.update(other)
+            other = other._data
+        self._data.update(other)
 
     @staticmethod
     def _flatten_dict(d: dict[str, Any], prefix: str = "", sep: str = ".") -> dict[str, Any]:
@@ -325,7 +329,7 @@ class Context:
             The flattened context values as a Python dictionary.
         """
 
-        return self._flatten_dict(self._ctx_dict, prefix="", sep=sep)
+        return self._flatten_dict(self._data, prefix="", sep=sep)
 
     @staticmethod
     def unflatten(d: dict[str, Any], sep: str = ".") -> dict[str, Any]:

--- a/src/nnbench/reporter/__init__.py
+++ b/src/nnbench/reporter/__init__.py
@@ -4,3 +4,4 @@ A lightweight interface for refining, displaying, and streaming benchmark result
 from __future__ import annotations
 
 from .base import BenchmarkReporter
+from .duckdb_sql import DuckDBReporter

--- a/src/nnbench/reporter/__init__.py
+++ b/src/nnbench/reporter/__init__.py
@@ -3,40 +3,4 @@ A lightweight interface for refining, displaying, and streaming benchmark result
 """
 from __future__ import annotations
 
-import importlib
-import types
-
 from .base import BenchmarkReporter
-
-# internal, mutable
-_reporter_registry: dict[str, type[BenchmarkReporter]] = {}
-
-# external, immutable
-reporter_registry: types.MappingProxyType[str, type[BenchmarkReporter]] = types.MappingProxyType(
-    _reporter_registry
-)
-
-
-def register_reporter(key: str, cls_or_name: str | type[BenchmarkReporter]) -> None:
-    """
-    Register a reporter class by its fully qualified module path.
-
-    Parameters
-    ----------
-    key: str
-        The key to register the reporter under. Subsequently, this key can be used in place
-        of reporter classes in code.
-    cls_or_name: str | type[BenchmarkReporter]
-        Name of or full module path to the reporter class. For example, when registering a class
-        ``MyReporter`` located in ``my_module``, ``name`` should be ``my_module.MyReporter``.
-    """
-
-    if isinstance(cls_or_name, str):
-        name = cls_or_name
-        modname, clsname = name.rsplit(".", 1)
-        mod = importlib.import_module(modname)
-        cls = getattr(mod, clsname)
-        _reporter_registry[key] = cls
-    else:
-        # name = cls_or_name.__module__ + "." + cls_or_name.__qualname__
-        _reporter_registry[key] = cls_or_name

--- a/src/nnbench/reporter/base.py
+++ b/src/nnbench/reporter/base.py
@@ -85,8 +85,7 @@ class BenchmarkReporter:
             A mapping of column names to custom formatters, i.e. functions formatting input
             values for display in the console.
         """
-        ctx, benchmarks = record["context"], record["benchmarks"]
-
+        benchmarks = record.benchmarks
         # This assumes a stable schema across benchmarks.
         if include is None:
             includes = set(benchmarks[0].keys())
@@ -108,7 +107,7 @@ class BenchmarkReporter:
                 continue
             filteredctx = {
                 k: v
-                for k, v in ctx.flatten().items()
+                for k, v in record.context.items()
                 if any(k.startswith(i) for i in include_context)
             }
             filteredbm = {k: v for k, v in bm.items() if k in cols}

--- a/src/nnbench/reporter/duckdb_sql.py
+++ b/src/nnbench/reporter/duckdb_sql.py
@@ -17,11 +17,11 @@ try:
 except ImportError:
     DUCKDB_INSTALLED = False
 
-from nnbench.reporter.file import FileReporter
+from nnbench.reporter.file import FileIO
 from nnbench.types import BenchmarkRecord
 
 
-class DuckDBReporter(FileReporter):
+class DuckDBReporter(FileIO):
     """
     A reporter for streaming benchmark results to duckdb.
 
@@ -85,7 +85,6 @@ class DuckDBReporter(FileReporter):
 
     def initialize(self):
         self.conn = duckdb.connect(self.dbname, read_only=self.read_only)
-        super().initialize()
 
     def finalize(self):
         if self.conn:
@@ -94,7 +93,7 @@ class DuckDBReporter(FileReporter):
         if self.delete:
             shutil.rmtree(self._directory, ignore_errors=True)
 
-    def read(
+    def read_sql(
         self,
         file: str | os.PathLike[str],
         driver: str | None = None,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -75,7 +75,7 @@ def test_update_with_unnested_dict():
     ctx = Context({"a": 1, "b": 2})
     ctx.update({"a": 3, "c": 4})
     expected_dict = {"a": 3, "b": 2, "c": 4}
-    assert ctx._ctx_dict == expected_dict
+    assert ctx._data == expected_dict
 
 
 def test_update_with_context_instance():
@@ -83,4 +83,4 @@ def test_update_with_context_instance():
     ctx2 = Context({"d": 4})
     ctx1.update(ctx2)
     expected_dict = {"a": 1, "b": {"c": 2}, "d": 4}
-    assert ctx1._ctx_dict == expected_dict
+    assert ctx1._data == expected_dict

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -52,9 +52,10 @@ def test_context_collection_in_runner(testfolder: str) -> None:
         context=context_providers,
     )
 
-    assert "system" in result["context"]
-    assert "cpuarch" in result["context"]
-    assert "python_version" in result["context"]
+    ctx = result.context
+    assert "system" in ctx
+    assert "cpuarch" in ctx
+    assert "python_version" in ctx
 
 
 def test_error_on_duplicate_context_keys_in_runner(testfolder: str) -> None:


### PR DESCRIPTION
This is a more comprehensive take on context handling before/after a
serialization. Options are now omitting, inlining, or flattening the
context.

Changes the `BenchmarkRecord` class to a dataclass, meaning everything
gets switched over to dotted access.

Turns the file reporter into an IO mixin, which is a good building block
for subsequent uses in other reporters.

----------------------------------------

[Remove reporter registration facility](https://github.com/aai-institute/nnbench/commit/61642861d5d07c253dcdda00d8ad2e83491ade51)

Currently unused, can be reintroduced later if needed.