### PR TITLE
Unify batching in file drivers, remove read/write stubs on base reporter

### DIFF
--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -217,10 +217,10 @@ def mnist_jax():
 
     # the nnbench portion.
     runner = nnbench.BenchmarkRunner()
-    reporter = nnbench.BenchmarkReporter()
+    reporter = nnbench.reporter.FileReporter()
     params = MNISTTestParameters(params=state.params, data=data)
     result = runner.run(HERE, params=params)
-    reporter.write(result)
+    reporter.write(result, "result.json")
 
 
 if __name__ == "__main__":

--- a/src/nnbench/reporter/__init__.py
+++ b/src/nnbench/reporter/__init__.py
@@ -5,3 +5,4 @@ from __future__ import annotations
 
 from .base import BenchmarkReporter
 from .duckdb_sql import DuckDBReporter
+from .file import FileReporter

--- a/src/nnbench/reporter/base.py
+++ b/src/nnbench/reporter/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Callable, Sequence
+from typing import Any, Callable
 
 from tabulate import tabulate
 
@@ -23,7 +23,8 @@ class BenchmarkReporter:
     the database in ``report_result()``, with preprocessing if necessary.
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._initialized = False
 
     def initialize(self):
@@ -120,17 +121,3 @@ class BenchmarkReporter:
             filtered.append(filteredbm)
 
         print(tabulate(filtered, headers="keys", tablefmt=tablefmt))
-
-    def read(self, *args: Any, **kwargs: Any) -> BenchmarkRecord:
-        raise NotImplementedError
-
-    def read_batched(self, *args: Any, **kwargs: Any) -> list[BenchmarkRecord]:
-        raise NotImplementedError
-
-    def write(self, record: BenchmarkRecord, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError
-
-    def write_batched(self, records: Sequence[BenchmarkRecord], *args: Any, **kwargs: Any) -> None:
-        # By default, just loop over the records and write() everything.
-        for record in records:
-            self.write(record, *args, **kwargs)


### PR DESCRIPTION
Since the reporter interface is so dynamic (i.e., file I/O needs vastly different arguments than DB I/O), we scrap the read/write APIs from the base class and add it as needed in the child classes.

Adds batched (i.e., multi-record) read/write support and a `FileReporter` class that is just the sum of the `FileIO` and `BenchmarkReporter` interfaces.