### PR TITLE
Add Parameters to Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ record = runner.run("__main__", params={"a": 2, "b": 10})
 rep = nnbench.BenchmarkReporter()
 rep.display(record)  # ...and print the results to the terminal.
 
-# results in a table like the following:
-# name     function    date                   value    time_ns
-# -------  ----------  -------------------  -------  ---------
-# product  product     2024-03-07T10:14:21       20       1000
-# power    power       2024-03-07T10:14:21     1024        750
+# results in a table look like the following:
+# name     function    date                 parameters         value    time_ns
+# -------  ----------  -------------------  -----------------  -------  ---------
+# product  product     2024-03-08T18:03:48  {'a': 2, 'b': 10}       20       1000
+# power    power       2024-03-08T18:03:48  {'a': 2, 'b': 10}     1024        750
 ```
 
 For a more realistic example of how to evaluate a trained model with a benchmark suite, check the [Quickstart](https://aai-institute.github.io/nnbench/latest/quickstart/).

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -264,7 +264,7 @@ class BenchmarkRunner:
                 "date": datetime.now().isoformat(timespec="seconds"),
                 "error_occurred": False,
                 "error_message": "",
-                "parameters": {**bmdefaults, **bmparams},
+                "parameters": bmdefaults | bmparams,
             }
             try:
                 benchmark.setUp(**bmparams)

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -89,7 +89,9 @@ class BenchmarkRunner:
                     )
 
                 if typ == empty:
-                    logger.debug(f"parameter {name!r} untyped in benchmark {bm.fn.__name__}().")
+                    logger.debug(
+                        f"parameter {name!r} untyped in benchmark {bm.fn.__name__}()."
+                    )
 
                 if name in allvars:
                     currvar = allvars[name]
@@ -134,7 +136,9 @@ class BenchmarkRunner:
         """Clear all registered benchmarks."""
         self.benchmarks.clear()
 
-    def collect(self, path_or_module: str | os.PathLike[str], tags: tuple[str, ...] = ()) -> None:
+    def collect(
+        self, path_or_module: str | os.PathLike[str], tags: tuple[str, ...] = ()
+    ) -> None:
         # TODO: functools.cache this guy
         """
         Discover benchmarks in a module and memoize them for later use.
@@ -226,7 +230,9 @@ class BenchmarkRunner:
 
         # if we still have no benchmarks after collection, warn and return an empty record.
         if not self.benchmarks:
-            warnings.warn(f"No benchmarks found in path/module {str(path_or_module)!r}.")
+            warnings.warn(
+                f"No benchmarks found in path/module {str(path_or_module)!r}."
+            )
             return BenchmarkRecord(context=Context(), benchmarks=[])
 
         params = params or {}
@@ -254,7 +260,10 @@ class BenchmarkRunner:
 
         results: list[dict[str, Any]] = []
         for benchmark in self.benchmarks:
-            bmparams = {k: v for k, v in dparams.items() if k in benchmark.interface.names}
+            bmparams = {
+                k: v for k, v in dparams.items() if k in benchmark.interface.names
+            }
+            bmdefaults = {k: v for (k, t, v) in benchmark.interface.variables}
             # TODO: Wrap this into an execution context
             res: dict[str, Any] = {
                 "name": benchmark.name,
@@ -263,6 +272,7 @@ class BenchmarkRunner:
                 "date": datetime.now().isoformat(timespec="seconds"),
                 "error_occurred": False,
                 "error_message": "",
+                "parameters": {**bmdefaults, **bmparams},
             }
             try:
                 benchmark.setUp(**bmparams)

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -89,9 +89,7 @@ class BenchmarkRunner:
                     )
 
                 if typ == empty:
-                    logger.debug(
-                        f"parameter {name!r} untyped in benchmark {bm.fn.__name__}()."
-                    )
+                    logger.debug(f"parameter {name!r} untyped in benchmark {bm.fn.__name__}().")
 
                 if name in allvars:
                     currvar = allvars[name]
@@ -136,9 +134,7 @@ class BenchmarkRunner:
         """Clear all registered benchmarks."""
         self.benchmarks.clear()
 
-    def collect(
-        self, path_or_module: str | os.PathLike[str], tags: tuple[str, ...] = ()
-    ) -> None:
+    def collect(self, path_or_module: str | os.PathLike[str], tags: tuple[str, ...] = ()) -> None:
         # TODO: functools.cache this guy
         """
         Discover benchmarks in a module and memoize them for later use.
@@ -230,9 +226,7 @@ class BenchmarkRunner:
 
         # if we still have no benchmarks after collection, warn and return an empty record.
         if not self.benchmarks:
-            warnings.warn(
-                f"No benchmarks found in path/module {str(path_or_module)!r}."
-            )
+            warnings.warn(f"No benchmarks found in path/module {str(path_or_module)!r}.")
             return BenchmarkRecord(context=Context(), benchmarks=[])
 
         params = params or {}
@@ -260,9 +254,7 @@ class BenchmarkRunner:
 
         results: list[dict[str, Any]] = []
         for benchmark in self.benchmarks:
-            bmparams = {
-                k: v for k, v in dparams.items() if k in benchmark.interface.names
-            }
+            bmparams = {k: v for k, v in dparams.items() if k in benchmark.interface.names}
             bmdefaults = {k: v for (k, t, v) in benchmark.interface.variables}
             # TODO: Wrap this into an execution context
             res: dict[str, Any] = {

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -255,7 +255,7 @@ class BenchmarkRunner:
         results: list[dict[str, Any]] = []
         for benchmark in self.benchmarks:
             bmparams = {k: v for k, v in dparams.items() if k in benchmark.interface.names}
-            bmdefaults = {k: v for (k, t, v) in benchmark.interface.variables}
+            bmdefaults = {k: v for (k, _, v) in benchmark.interface.variables}
             # TODO: Wrap this into an execution context
             res: dict[str, Any] = {
                 "name": benchmark.name,

--- a/tests/benchmarks/parametrized.py
+++ b/tests/benchmarks/parametrized.py
@@ -1,0 +1,6 @@
+import nnbench
+
+
+@nnbench.parametrize([{"a": 1}, {"a": 2}], tags=("parametrized",))
+def double(a: int) -> int:
+    return 2 * 2

--- a/tests/benchmarks/parametrized.py
+++ b/tests/benchmarks/parametrized.py
@@ -1,6 +1,0 @@
-import nnbench
-
-
-@nnbench.parametrize([{"a": 1}, {"a": 2}], tags=("parametrized",))
-def double(a: int) -> int:
-    return 2 * 2

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -71,3 +71,21 @@ def test_error_on_duplicate_context_keys_in_runner(testfolder: str) -> None:
             params={"x": 1, "y": 1},
             context=context_providers,
         )
+
+
+def test_filter_benchmarks_on_params(testfolder: str) -> None:
+    r = nnbench.BenchmarkRunner()
+    results = r.run(testfolder, tags=("parametrized",))
+    print(results)
+    assert len(results.benchmarks) == 2
+    assert (
+        len(
+            list(
+                filter(
+                    lambda bm: bm["parameters"]["a"] == 1,
+                    results.benchmarks,
+                )
+            )
+        )
+        == 1
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -74,18 +74,15 @@ def test_error_on_duplicate_context_keys_in_runner(testfolder: str) -> None:
 
 
 def test_filter_benchmarks_on_params(testfolder: str) -> None:
+    @nnbench.benchmark
+    def prod(a: int, b: int = 1) -> int:
+        return a * b
+
     r = nnbench.BenchmarkRunner()
-    results = r.run(testfolder, tags=("parametrized",))
-    print(results)
-    assert len(results.benchmarks) == 2
-    assert (
-        len(
-            list(
-                filter(
-                    lambda bm: bm["parameters"]["a"] == 1,
-                    results.benchmarks,
-                )
-            )
-        )
-        == 1
-    )
+    r.benchmarks.append(prod)
+    # TODO (nicholasjng): This is hacky
+    rec1 = r.run("", params={"a": 1, "b": 2})
+    assert rec1.benchmarks[0]["parameters"] == {"a": 1, "b": 2}
+    # Assert that the defaults are also present if not overridden.
+    rec2 = r.run("", params={"a": 1})
+    assert rec2.benchmarks[0]["parameters"] == {"a": 1, "b": 1}


### PR DESCRIPTION
Closes #101 

Add the Parameters to a 'BenchmarkRecord' by appending it to the results. Omit the type information from the `Variable` object and only retain variable name and value.