### PR TITLE
Remove the `ArtifactCollection` class

### DIFF
--- a/docs/tutorials/artifact_benchmarking.md
+++ b/docs/tutorials/artifact_benchmarking.md
@@ -52,7 +52,7 @@ The benchmarking code is written to be executed as a script that consumes any nu
 The parsing of the arguments is handled by the last lines in the script which then calls the `main()` function:
 
 ```python
---8<-- "examples/artifact_benchmarking/src/runner.py:92:96"
+--8<-- "examples/artifact_benchmarking/src/runner.py:91:95"
 ```
 
 ### Artifact Classes
@@ -69,7 +69,7 @@ This attribute is set by the `ArtifactLoader` (which we will cover in a moment) 
 In our derived class, we have to override the `deserialize()` method to properly load the artifact value into memory.
 
 ```python
---8<-- "examples/artifact_benchmarking/src/runner.py:59"
+--8<-- "examples/artifact_benchmarking/src/runner.py:57"
 ```
 
 The `deserialize()` method has to set the `self._value` attribute to the value we want to access later.
@@ -99,17 +99,8 @@ We have a little more logic with respect to the dataset as we handle the train t
 --8<-- "examples/artifact_benchmarking/src/runner.py:19:27"
 ```
 
-### Artifact Collections
-The `ArtifactCollection` object is a convenient wrapper around `Artifact`s to allow for iteration and abstract away the `deserialize()` call. 
-We can instantiate them by passing an iterable of `Artifact`s.
+Now we execute the benchmark in the loop over the different models.
 
 ```python
---8<-- "examples/artifact_benchmarking/src/runner.py:56"
-```
-
-We can then either iterate over the `ArtifactCollection` directly, using the lazy deserialization, or we use the `.values()` method to return whatever we assigned to the `._values` attribute of the `Artifact`s.
-We then execute the benchmark in the loop for the different models we have supplied to the `ArtifactCollection`.
-
-```python
---8<-- "examples/artifact_benchmarking/src/runner.py:61:89"
+--8<-- "examples/artifact_benchmarking/src/runner.py:59:87"
 ```

--- a/docs/tutorials/artifact_benchmarking.md
+++ b/docs/tutorials/artifact_benchmarking.md
@@ -69,7 +69,7 @@ This attribute is set by the `ArtifactLoader` (which we will cover in a moment) 
 In our derived class, we have to override the `deserialize()` method to properly load the artifact value into memory.
 
 ```python
---8<-- "examples/artifact_benchmarking/src/runner.py:57"
+--8<-- "examples/artifact_benchmarking/src/runner.py:56:57"
 ```
 
 The `deserialize()` method has to set the `self._value` attribute to the value we want to access later.
@@ -102,5 +102,5 @@ We have a little more logic with respect to the dataset as we handle the train t
 Now we execute the benchmark in the loop over the different models.
 
 ```python
---8<-- "examples/artifact_benchmarking/src/runner.py:59:87"
+--8<-- "examples/artifact_benchmarking/src/runner.py:59:88"
 ```

--- a/examples/artifact_benchmarking/src/runner.py
+++ b/examples/artifact_benchmarking/src/runner.py
@@ -53,12 +53,10 @@ def main(model_paths: list[str]) -> None:
         TokenClassificationModel(loader=types.LocalArtifactLoader(path)) for path in model_paths
     ]
 
-    model_store = types.ArtifactCollection(*models)
-
     conllpp = ConllValidationData(ConllppLoader("conllpp", split="validation"))
     conllpp.deserialize()
 
-    for model, tokenizer in model_store.values():
+    for model, tokenizer in [model.value for model in models]:
         dataset, id2label = conllpp.value
         tokenized_dataset = dataset.map(
             lambda examples: tokenize_and_align_labels(tokenizer, examples),
@@ -86,7 +84,7 @@ def main(model_paths: list[str]) -> None:
             ),
             tags=("metric", "model-meta"),
         )
-        console_reporter.display(result)
+        console_reporter.display(result, exclude=("parameters",))
 
 
 if __name__ == "__main__":

--- a/examples/artifact_benchmarking/src/runner.py
+++ b/examples/artifact_benchmarking/src/runner.py
@@ -56,7 +56,8 @@ def main(model_paths: list[str]) -> None:
     conllpp = ConllValidationData(ConllppLoader("conllpp", split="validation"))
     conllpp.deserialize()
 
-    for model, tokenizer in [model.value for model in models]:
+    for mod in models:
+        model, tokenizer = mod.value
         dataset, id2label = conllpp.value
         tokenized_dataset = dataset.map(
             lambda examples: tokenize_and_align_labels(tokenizer, examples),

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import collections.abc
 import copy
 import inspect
 import os
@@ -16,8 +15,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Iterable,
-    Iterator,
     Literal,
     TypeVar,
 )
@@ -254,53 +251,6 @@ class Artifact(Generic[T], metaclass=ABCMeta):
         if self._value is None:
             self.deserialize()
         return self._value
-
-
-class ArtifactCollection(Generic[T], collections.abc.Iterable[Artifact[T]]):
-    """
-    A collection wrapper around multiple Artifact instances.
-    """
-
-    def __init__(self, *artifacts: Artifact[T]) -> None:
-        self._artifacts = [art for art in artifacts]
-
-    def add(self, artifacts: Artifact[T] | Iterable[Artifact[T]]) -> None:
-        """
-        Adds a single Artifact or an Iterable of Artifacts to the collection.
-
-        Parameters
-        ----------
-        artifacts : Artifact[T] | Iterable[Artifact[T]]
-            The Artifact instance(s) to add to the collection.
-        """
-        if isinstance(artifacts, Iterable):
-            self._artifacts.extend(artifacts)
-        else:
-            self._artifacts.append(artifacts)
-
-    def __iter__(self) -> Iterator[Artifact[T]]:
-        """
-        Iterator over deserialized artifacts in the collection.
-
-        Yields
-        -------
-        Iterator[Artifact[T]]
-            An iterator over deserialized artifacts in the collection.
-        """
-        for artifact in self._artifacts:
-            yield artifact
-
-    def values(self) -> Iterator[T]:
-        """
-        Iterator over the values of deserialized artifacts in the collection.
-
-        Yields
-        ------
-        Iterator[T]
-            An iterator over the values of the deserialized artifacts.
-        """
-        for artifact in self:
-            yield artifact.value
 
 
 @dataclass(init=False, frozen=True)


### PR DESCRIPTION
It is redundant as we have added the deserialization logic in the `Artifact.value` call.
It was therefore only a somewhat useless wrapper around a list. 
Removed mentions from docs as well.

Closes #108 