### PR TITLE
Add checksum verification to artifacts and loaders

### DIFF
--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -243,6 +243,9 @@ class BenchmarkRunner:
         for benchmark in self.benchmarks:
             bmparams = {k: v for k, v in dparams.items() if k in benchmark.interface.names}
             bmdefaults = {k: v for (k, _, v) in benchmark.interface.variables}
+            # for k, v in bmparams:
+            #     if isinstance(v, Artifact):
+            #         v.deserialize(loader) <- loader.load(v.path) -> download or cache lookup.
             # TODO: Wrap this into an execution context
             res: dict[str, Any] = {
                 "name": benchmark.name,

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -111,14 +111,10 @@ class BenchmarkRecord:
 
 class ArtifactLoader:
     @abstractmethod
-    def load(
-        self, rpath: str | os.PathLike[str], checksum: str | None = None
-    ) -> os.PathLike[str]:
+    def load(self, rpath: str | os.PathLike[str], checksum: str | None = None) -> os.PathLike[str]:
         """Load the artifact."""
 
-    def verify(
-        self, rpath: str | os.PathLike[str], expected: str, blocksize: int = 2**22
-    ) -> None:
+    def verify(self, rpath: str | os.PathLike[str], expected: str, blocksize: int = 2**22) -> None:
         """Verify an artifact path checksum against an expected value."""
 
 
@@ -150,9 +146,7 @@ class PathArtifactLoader(ArtifactLoader):
             from fsspec import AbstractFileSystem, filesystem
             from fsspec.utils import get_protocol
 
-            fs: AbstractFileSystem = filesystem(
-                get_protocol(str(rpath)), **self.storage_options
-            )
+            fs: AbstractFileSystem = filesystem(get_protocol(str(rpath)), **self.storage_options)
 
             if not fs.exists(rpath):
                 raise FileNotFoundError(rpath)
@@ -178,9 +172,7 @@ class PathArtifactLoader(ArtifactLoader):
                 self.verify(rpath, checksum)
             return Path(rpath).resolve()
 
-    def verify(
-        self, rpath: str | os.PathLike[str], expected: str, blocksize: int = 2**22
-    ) -> None:
+    def verify(self, rpath: str | os.PathLike[str], expected: str, blocksize: int = 2**22) -> None:
         with open(rpath, "rb") as f:
             chunk = f.read(blocksize)
             while chunk:
@@ -222,9 +214,7 @@ class Artifact(Generic[T], metaclass=ABCMeta):
         A checksum to optionally verify artifact integrity with before loading the artifact.
     """
 
-    def __init__(
-        self, path: str | os.PathLike[str], checksum: str | None = None
-    ) -> None:
+    def __init__(self, path: str | os.PathLike[str], checksum: str | None = None) -> None:
         self._path = path
         self._checksum = checksum
         # self.path = loader.load(checksum)  # fetch the artifact from wherever it resides

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 
-from nnbench.types import FilePathArtifactLoader
+from nnbench.types import PathArtifactLoader
 
 
-def test_load_local_file(local_file: Path, tmp_path: Path) -> None:
-    test_dir = tmp_path / "test_load_dir"
-    loader = FilePathArtifactLoader(local_file, test_dir)
-    loaded_path: Path = loader.load()
+def test_load_local_file(local_file: Path) -> None:
+    loader = PathArtifactLoader()
+    loaded_path: Path = loader.load(local_file)
     assert loaded_path.exists()
     assert loaded_path.read_text() == "Test content"

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 
 from nnbench.types import PathArtifactLoader
@@ -8,3 +9,21 @@ def test_load_local_file(local_file: Path) -> None:
     loaded_path: Path = loader.load(local_file)
     assert loaded_path.exists()
     assert loaded_path.read_text() == "Test content"
+
+
+def test_caching_PathArtifactLoader(local_file: Path) -> None:
+    artifact_loader = PathArtifactLoader()
+
+    # Measure the time for the first load
+    start_time_first_load = time.perf_counter()
+    artifact_loader.load(local_file)
+    end_time_first_load = time.perf_counter()
+
+    # Measure the time for the second, cached load
+    start_time_second_load = time.perf_counter()
+    artifact_loader.load(local_file)
+    end_time_second_load = time.perf_counter()
+
+    first_load_duration = end_time_first_load - start_time_first_load
+    second_load_duration = end_time_second_load - start_time_second_load
+    assert second_load_duration < first_load_duration


### PR DESCRIPTION
In preparation for the string representation of artifacts that can be saved to other places while keeping reproducibility.

Missing pieces:

- [ ] Tests
- [ ] `Artifact.to_json()/to_dict()` hook in preparation for transforms.