### PR TITLE
Unique keys

### DIFF
--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -215,11 +215,6 @@ class BenchmarkRunner:
             A JSON output representing the benchmark results. Has two top-level keys, "context"
             holding the context information, and "benchmarks", holding an array with the
             benchmark results.
-
-        Raises
-        ------
-        ValueError
-            If any context value is provided more than once.
         """
         if not self.benchmarks:
             self.collect(path_or_module, tags)
@@ -241,16 +236,8 @@ class BenchmarkRunner:
             ctx = context
         else:
             ctx = Context()
-
             for provider in context:
-                ctx_cand = Context.make(provider())
-
-                # we do not allow multiple values for a context key.
-                duplicates = set(ctx.keys()) & set(ctx_cand.keys())
-                if duplicates:
-                    dupe, *_ = duplicates
-                    raise ValueError(f"got multiple values for context key {dupe!r}")
-                ctx.update(ctx_cand)
+                ctx.add(provider)
 
         results: list[dict[str, Any]] = []
         for benchmark in self.benchmarks:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,3 +1,5 @@
+import pytest
+
 from nnbench.context import Context, CPUInfo, GitEnvironmentInfo, PythonInfo
 
 
@@ -71,17 +73,30 @@ def test_context_items():
     assert set(ctx.items()) == expected_items
 
 
+def test_context_update_with_key_collision():
+    ctx = Context({"a": 1, "b": 2})
+    with pytest.raises(ValueError, match=r".*multiple values for context.*"):
+        ctx.update(Context.make({"a": 3, "c": 4}))
+
+
+def test_context_update_duplicate_with_replace():
+    ctx = Context({"a": 1, "b": 2})
+    ctx.update(Context.make({"a": 3, "c": 4}), replace=True)
+    expected_dict = {"a": 3, "b": 2, "c": 4}
+    assert ctx._data == expected_dict
+
+
 def test_update_with_context():
     ctx = Context({"a": 1, "b": 2})
-    ctx.update(Context.make({"a": 3, "c": 4}))
-    expected_dict = {"a": 3, "b": 2, "c": 4}
+    ctx.update(Context.make({"c": 4}))
+    expected_dict = {"a": 1, "b": 2, "c": 4}
     assert ctx._data == expected_dict
 
 
 def test_add_with_provider():
     ctx = Context({"a": 1, "b": 2})
-    ctx.add(lambda: {"a": 3, "c": 4})
-    expected_dict = {"a": 3, "b": 2, "c": 4}
+    ctx.add(lambda: {"c": 4})
+    expected_dict = {"a": 1, "b": 2, "c": 4}
     assert ctx._data == expected_dict
 
 


### PR DESCRIPTION
Closes #99 

The `.add` and `.update` methods of the `Context` now check for
key collisions. With the `replace=False` `kwarg` the user can cus-
tomize the behaviour. Upon collision a ValueError is raised.

Remove collision logic from `runner.run` method as it is now hand-
led in the `Context.add` method.

The `.add` method is implemented in term of `.update` to stay DRY.

Change some tests as they contained key collisions.
Updated tests test the desired behaviour based upon the `replace`
flag.