### PR TITLE
`functools.partial`ize the `nnbench.parametrize` decorators.

### DIFF
--- a/docs/tutorials/artifact_benchmarking.md
+++ b/docs/tutorials/artifact_benchmarking.md
@@ -43,6 +43,9 @@ We are not walking through the whole file but instead point out certain design c
 If you are interested in a more detailed walkthrough on how to set up benchmarks, you can find it [here](../guides/benchmarks.md).
 Notable design choices in this benchmark are that we factored out the evaluation loop as it is necessary for all evaluation metrics. We cache it using the `functools.lru_cache` decorator so the evaluation loop runs only once per benchmark run instead of once per metric which greatly reduces runtime.
 We use `nnbench.parametrize` to get the per-class metrics. 
+As the parametrization method needs the same arguments for each benchmark, we use Python's builtin `functools.partial` to fill the arguments.
+One noteworthy subtlety here is that we need to call the partial immediately so it returns the pre-filled `nnbench.parametrize` decorators.
+If we don't do that, the `runner.collect` does not find the respective benchmarks. 
 
 ## Running Benchmarks with saved Artifacts
 Now that we have explained the example, let's jump into the benchmarking code.

--- a/examples/artifact_benchmarking/src/benchmark.py
+++ b/examples/artifact_benchmarking/src/benchmark.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import time
-from functools import lru_cache
+from functools import lru_cache, partial
 
 import torch
 from torch.nn import Module
@@ -48,7 +48,8 @@ def precision(model: Module, test_dataloader: DataLoader, padding_id: int = -100
     return torch.mean(precision).item()
 
 
-@nnbench.parametrize(
+parametrize_label = partial(
+    nnbench.parametrize,
     (
         {"class_label": "O"},
         {"class_label": "B-PER"},
@@ -61,7 +62,10 @@ def precision(model: Module, test_dataloader: DataLoader, padding_id: int = -100
         {"class_label": "I-MISC"},
     ),
     tags=("metric", "per-class"),
-)
+)()
+
+
+@parametrize_label
 def precision_per_class(
     class_label: str,
     model: Module,
@@ -84,20 +88,7 @@ def recall(model: Module, test_dataloader: DataLoader, padding_id: int = -100) -
     return torch.mean(recall).item()
 
 
-@nnbench.parametrize(
-    (
-        {"class_label": "O"},
-        {"class_label": "B-PER"},
-        {"class_label": "I-PER"},
-        {"class_label": "B-ORG"},
-        {"class_label": "I-ORG"},
-        {"class_label": "B-LOC"},
-        {"class_label": "I-LOC"},
-        {"class_label": "B-MISC"},
-        {"class_label": "I-MISC"},
-    ),
-    tags=("metric", "per-class"),
-)
+@parametrize_label
 def recall_per_class(
     class_label: str,
     model: Module,
@@ -122,20 +113,7 @@ def f1(model: Module, test_dataloader: DataLoader, padding_id: int = -100) -> fl
     return torch.mean(f1).item()
 
 
-@nnbench.parametrize(
-    (
-        {"class_label": "O"},
-        {"class_label": "B-PER"},
-        {"class_label": "I-PER"},
-        {"class_label": "B-ORG"},
-        {"class_label": "I-ORG"},
-        {"class_label": "B-LOC"},
-        {"class_label": "I-LOC"},
-        {"class_label": "B-MISC"},
-        {"class_label": "I-MISC"},
-    ),
-    tags=("metric", "per-class"),
-)
+@parametrize_label
 def f1_per_class(
     class_label: str,
     model: Module,
@@ -160,20 +138,7 @@ def accuracy(model: Module, test_dataloader: DataLoader, padding_id: int = -100)
     return torch.mean(accuracy).item()
 
 
-@nnbench.parametrize(
-    (
-        {"class_label": "O"},
-        {"class_label": "B-PER"},
-        {"class_label": "I-PER"},
-        {"class_label": "B-ORG"},
-        {"class_label": "I-ORG"},
-        {"class_label": "B-LOC"},
-        {"class_label": "I-LOC"},
-        {"class_label": "B-MISC"},
-        {"class_label": "I-MISC"},
-    ),
-    tags=("metric", "per-class"),
-)
+@parametrize_label
 def accuracy_per_class(
     class_label: str,
     model: Module,


### PR DESCRIPTION
To use `functools.partial` for `parametrize` (and `product`) it is necessary to call the function returned by `partial`. Other- wise collection does not work.

Add these insights in the guide and example.

Closes #96 