### PR TITLE
Update dev requirements, add Memray artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,8 @@ public/
 
 # NumPy zip archives created by the examples.
 *.npz
+
+# Memray flamegraphs and their HTML views
+*.bin
+*.html
+!docs/**/*.html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --explicit-package-bases]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.2
+    rev: v0.3.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,8 @@
 build==1.1.1
 cfgv==3.4.0
 distlib==0.3.8
-filelock==3.13.1
+filelock==3.13.3
+fsspec==2024.3.1
 identify==2.5.35
 iniconfig==2.0.0
 nodeenv==1.8.0
@@ -15,9 +16,9 @@ numpy==1.26.4
 packaging==24.0
 platformdirs==4.2.0
 pluggy==1.4.0
-pre-commit==3.6.2
+pre-commit==3.7.0
 psutil==5.9.8
-pyarrow==15.0.1
+pyarrow==15.0.2
 pyproject-hooks==1.0.0
 pytest==8.1.1
 pyyaml==6.0.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,7 +6,7 @@
 #
 anyio==4.3.0
 babel==2.14.0
-black==24.2.0
+black==24.3.0
 certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7
@@ -15,13 +15,13 @@ docstring-parser==0.16
 essentials==1.1.5
 essentials-openapi==1.0.9
 ghp-import==2.1.0
-griffe==0.41.3
+griffe==0.42.1
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0
 idna==3.6
-importlib-metadata==7.0.2
-importlib-resources==6.1.3
+importlib-metadata==7.1.0
+importlib-resources==6.4.0
 jinja2==3.1.3
 markdown==3.5.2
 markdown-it-py==3.0.0
@@ -35,11 +35,11 @@ mkdocs-callouts==1.13.2
 mkdocs-gen-files==0.5.0
 mkdocs-include-dir-to-nav==1.2.0
 mkdocs-literate-nav==0.6.1
-mkdocs-material==9.5.13
+mkdocs-material==9.5.15
 mkdocs-material-extensions==1.3.1
 mkdocs-section-index==0.3.8
 mkdocstrings[python]==0.24.1
-mkdocstrings-python==1.8.0
+mkdocstrings-python==1.9.0
 mypy-extensions==1.0.0
 neoteroi-mkdocs==1.0.5
 packaging==24.0
@@ -61,4 +61,4 @@ tabulate==0.9.0
 urllib3==2.2.1
 verspec==0.1.0
 watchdog==4.0.0
-zipp==3.17.0
+zipp==3.18.1

--- a/src/nnbench/types/types.py
+++ b/src/nnbench/types/types.py
@@ -153,8 +153,6 @@ class Benchmark:
         A teardown hook run after the benchmark. Must take all members of `params` as inputs.
     tags: tuple[str, ...]
         Additional tags to attach for bookkeeping and selective filtering during runs.
-    interface: Interface
-        Interface of the benchmark function.
     """
 
     fn: Callable[..., Any]


### PR DESCRIPTION
This is useful to have when profiling memory usage on nnbench.