### PR TITLE
Implement memo garbage collection

### DIFF
--- a/docs/guides/memoization.md
+++ b/docs/guides/memoization.md
@@ -6,8 +6,6 @@ Especially when loading and benchmarking several models in succession, for examp
 To address this problem, this guide introduces **memos** as a way to reduce memory pressure when benchmarking multiple memory-intensive models and datasets sequentially.
 
 ## Using the `nnbench.Memo` class
-// TODO: Move the class up into the main export.
-
 The key to efficient memory utilization in nnbench is _memoization_.
 nnbench itself provides the `nnbench.Memo` class, a generic base class that can be subclassed to yield a value and cache it for subsequent invocations.
 
@@ -15,19 +13,20 @@ To subclass a memo, overload the `Memo.__call__()` operator like so:
 
 ```python
 import numpy as np
-import nnbench
+from nnbench.types import Memo, cached_memo
 
 class MyType:
     """Contains a huge array, similarly to a model."""
     a: np.ndarray = np.zeros((10000, 10000))
 
-class MyMemo(nnbench.Memo[MyType]):
+class MyMemo(Memo[MyType]):
     
-    # TODO: Add a memo cache decorator.
+    @cached_memo
     def __call__(self) -> MyType:
         return MyType()
 ```
 
+The most important part of the above definition is the `@cached_memo` decorator, which adds the computed value to a module-level cache, from where it can be reused when requested.
 `nnbench.Memo` objects do not take any arguments, meaning that all external state necessary to compute the value needs to be passed in the `Memo.__init__()` function.
 In this way, nnbench's memos work similarly to e.g. [React's useMemo hook](https://react.dev/reference/react/useMemo).
 
@@ -40,13 +39,16 @@ In this way, nnbench's memos work similarly to e.g. [React's useMemo hook](https
 Memoization is especially useful when parametrizing benchmarks over models and datasets.
 
 Suppose we have a `Model` class wrapping a large (in the order of available memory) NumPy array.
-If we cannot load all models into memory at the same time in a benchmark run, we can load the (serialized) models one by one using nnbench memos.
+If we have multiple `Model` instances, but cannot load all of them into memory at the same time in a benchmark run, we can load the (serialized) models lazily using nnbench memos.
 
 ```python
-import nnbench
+import gc
 
 import numpy as np
 
+import nnbench
+from nnbench.types import Memo, cached_memo
+from nnbench.types.memo import evict_memo, get_memo_by_value
 
 class Model:
     def __init__(self, arr: np.ndarray):
@@ -55,26 +57,33 @@ class Model:
     def apply(self, arr: np.ndarray) -> np.ndarray:
         return self.array @ arr
 
-class ModelMemo(nnbench.Memo[Model]):
+class ModelMemo(Memo[Model]):
     def __init__(self, path):
         self.path = path
     
-    # TODO: Add a memo cache decorator.
+    @cached_memo
     def __call__(self) -> Model:
         arr = np.load(self.path)
         return Model(arr)
+    
+
+def tearDown(state, params):
+    print("Evicting memo for benchmark parameter 'model':")
+    m = get_memo_by_value(params["model"])
+    if m is not None:
+        evict_memo(m)
+        gc.collect()
 
 
 @nnbench.product(
-    model=[ModelMemo(p) for p in ("model1.npz", "model2.npz", "model3.npz")]
+    model=[ModelMemo(p) for p in ("model1.npz", "model2.npz", "model3.npz")],
+    tearDown=tearDown,
 )
 def accuracy(model: Model, data: np.ndarray) -> float:
     return np.sum(model.apply(data))
 ```
 
-//TODO: Add tearDown task clearing the memo cache.
-
-After each benchmark, each model memo's corresponding value is evicted from nnbench's memoization cache.
+After each benchmark, each model memo's corresponding value is evicted from nnbench's memoization cache in the `tearDown` task.
 
 !!! Warning
     If you evict a value before its last use in a benchmark, it will be recomputed, potentially slowing down benchmark execution by a lot.

--- a/src/nnbench/types/memo.py
+++ b/src/nnbench/types/memo.py
@@ -62,6 +62,13 @@ def evict_memo(_id: int) -> Any:
         return _memo_cache.pop(_id)
 
 
+def get_memo_by_value(val: Any) -> int | None:
+    for k, v in _memo_cache.items():
+        if v is val:
+            return k
+    return None
+
+
 def cached_memo(fn: Callable) -> Callable:
     """
     Decorator that caches the result of a method call based on the instance ID.


### PR DESCRIPTION
Two steps:

1) Add back the compressed parameter representation to nnbench's runner. There is unfortunately no other way around this, since we have no way out after the record gets persisted.
2) Implement another memo cache API, getting a memo ID (or None) for a memoized value. This is needed for eviction in teardown tasks, which are passed the memo values and not the memos themselves.

The documentation on memos was amended to showcase a dealloc in a teardown task.

The repro on a ~1GB array:

```python
import gc
import logging
import numpy as np

import nnbench
from nnbench.types import Memo, cached_memo
from nnbench.types.memo import evict_memo, get_memo_by_value, memo_cache_size


logging.basicConfig()
logger = logging.getLogger("nnbench")
logger.setLevel(logging.DEBUG)


class MyMemo(Memo[np.ndarray]):
    @cached_memo
    def __call__(self) -> np.ndarray:
        return np.random.random_sample((10000, 10000))


def tearDown(state, params):
    logger.debug(f"Current memo cache size: {memo_cache_size()}")
    logger.debug("Evicting memo for benchmark parameter 'a':")
    m = get_memo_by_value(params["a"])
    if m is not None:
        evict_memo(m)
        gc.collect()
    logger.debug(f"New memo cache size: {memo_cache_size()}")


@nnbench.product(a=[MyMemo(), MyMemo(), MyMemo(), MyMemo()], tearDown=tearDown)
def matrixmult(a: np.ndarray, b: np.ndarray):
    return a @ b


if __name__ == "__main__":

    lhs = np.random.random_sample((10000,))

    runner = nnbench.BenchmarkRunner()
    res = runner.run(__name__, params={"b": lhs})
    print(res.benchmarks[0]["parameters"])
```


Image proof that it works (from the memray flamegraph):
<img width="1440" alt="Screenshot 2024-03-27 at 15 46 13" src="https://github.com/aai-institute/nnbench/assets/54248170/17944451-7565-444e-bd34-63f07a432159">


(The deallocs are the orange downward spikes.)

Closes #105.