### PR TITLE
Safe setting of CPU Info

### DIFF
--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -180,7 +180,7 @@ class CPUInfo:
             freq_conversion = self.conversion_table[self.frequnit[0]]
             # result is in MHz, so we convert to Hz and apply the conversion factor.
             result["frequency"] = freq_struct.current * 1e6 / freq_conversion
-        except Exception:
+        except RuntimeError:
             result["frequency"] = 0
             result["min_frequency"] = 0
             result["max_frequency"] = 0

--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -172,13 +172,20 @@ class CPUInfo:
         result["system"] = platform.system()
         result["system-version"] = platform.release()
 
-        freq_struct = psutil.cpu_freq()
-        freq_conversion = self.conversion_table[self.frequnit[0]]
-        # result is in MHz, so we convert to Hz and apply the conversion factor.
-        result["frequency"] = freq_struct.current * 1e6 / freq_conversion
+        try:
+            # The CPU frequency is not available on some ARM devices
+            freq_struct = psutil.cpu_freq()
+            result["min_frequency"] = freq_struct.min
+            result["max_frequency"] = freq_struct.max
+            freq_conversion = self.conversion_table[self.frequnit[0]]
+            # result is in MHz, so we convert to Hz and apply the conversion factor.
+            result["frequency"] = freq_struct.current * 1e6 / freq_conversion
+        except Exception:
+            result["frequency"] = 0
+            result["min_frequency"] = 0
+            result["max_frequency"] = 0
+
         result["frequency_unit"] = self.frequnit
-        result["min_frequency"] = freq_struct.min
-        result["max_frequency"] = freq_struct.max
         result["num_cpus"] = psutil.cpu_count(logical=False)
         result["num_logical_cpus"] = psutil.cpu_count()
 

--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import itertools
-import logging
 import platform
 import sys
 from typing import Any, Callable, Iterator, Literal
@@ -165,39 +164,29 @@ class CPUInfo:
             )
 
         result: dict[str, Any] = dict()
-        logger = logging.getLogger(__name__)
-
-        def safe_set(key: str, value: Callable) -> None:
-            try:
-                result[key] = value()
-            except Exception as e:
-                logger.warning(f"Failed saving value for {key}: {e}")
-                result[key] = None
 
         # first, the platform info.
-        safe_set("architecture", platform.machine)
-        safe_set("bitness", lambda: platform.architecture()[0])
-        safe_set("processor", platform.processor)
-        safe_set("system", platform.system)
-        safe_set("system-version", platform.release)
+        result["architecture"] = platform.machine()
+        result["bitness"] = platform.architecture()[0]
+        result["processor"] = platform.processor()
+        result["system"] = platform.system()
+        result["system-version"] = platform.release()
 
-        safe_set(
-            "frequency",
-            # result is in MHz, so we convert to Hz and apply the conversion factor.
-            lambda: psutil.cpu_freq().current * 1e6 / self.conversion_table[self.frequnit[0]],
-        )
-        safe_set("frequency_unit", lambda: self.frequnit)
-        safe_set("min_frequency", lambda: psutil.cpu_freq().min)
-        safe_set("max_frequency", lambda: psutil.cpu_freq().max)
-        safe_set("num_cpus", lambda: psutil.cpu_count(logical=False))
-        safe_set("num_logical_cpus", psutil.cpu_count)
+        freq_struct = psutil.cpu_freq()
+        freq_conversion = self.conversion_table[self.frequnit[0]]
+        # result is in MHz, so we convert to Hz and apply the conversion factor.
+        result["frequency"] = freq_struct.current * 1e6 / freq_conversion
+        result["frequency_unit"] = self.frequnit
+        result["min_frequency"] = freq_struct.min
+        result["max_frequency"] = freq_struct.max
+        result["num_cpus"] = psutil.cpu_count(logical=False)
+        result["num_logical_cpus"] = psutil.cpu_count()
 
-        safe_set(
-            "total_memory",
-            # result is in bytes, so no need for base conversion.
-            lambda: psutil.virtual_memory().total / self.conversion_table[self.memunit[0]],
-        )
-        safe_set("memory_unit", lambda: self.memunit)
+        mem_struct = psutil.virtual_memory()
+        mem_conversion = self.conversion_table[self.memunit[0]]
+        # result is in bytes, so no need for base conversion.
+        result["total_memory"] = mem_struct.total / mem_conversion
+        result["memory_unit"] = self.memunit
         # TODO: Lacks CPU cache info, which requires a solution other than psutil.
         return {self.key: result}
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -38,7 +38,7 @@ def test_cpu_info_provider() -> None:
     # the popular CPU architectures.
     assert res["architecture"] != ""
     assert res["system"] != ""
-    assert res["frequency"] > 0
+    assert res["frequency"] >= 0
     assert res["num_cpus"] > 0
     assert res["total_memory"] > 0
 


### PR DESCRIPTION
as the context information might not be available on all devices, e.g. in our GitHub CI VM the CPU frequency.

Wrap setting of dict entry in a try, except blog that throws warnings when a value cannot be obtained.

This is to address the CI failure described in #145 and very much a suggestion that we can discuss. 

In any case, I think a failure of getting context info should not break the test execution in case they take some time.
As a data scientist using nnbench, I would want our suite to run through so i can react to failures. However, I definitely want information about missing values such that i can implement fixes to these in case they are crucial. 