### PR TITLE
Remove setuptools_scm in favor of explicit version management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools-scm[toml]>=7.1"]
+requires = ["setuptools>=45"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,6 @@ name = "nnbench"
 description = "A small framework for benchmarking machine learning models."
 keywords = ["Benchmarking", "Machine Learning"]
 requires-python = ">=3.10"
-readme = "README.md"
 license = { text = "Apache-2.0" }
 authors = [{ name = "appliedAI Initiative", email = "info+oss@appliedai.de" }]
 maintainers = [
@@ -33,7 +32,7 @@ classifiers = [
 
 dependencies = ["tabulate", "typing-extensions; python_version< '3.11'"]
 
-dynamic = ["version"]
+dynamic = ["readme", "version"]
 
 [project.urls]
 Homepage = "https://github.com/aai-institute/nnbench"
@@ -71,14 +70,15 @@ nnbench = "nnbench.cli:main"
 [tool.setuptools]
 package-dir = { "" = "src" }
 
+[tool.setuptools.dynamic]
+readme = { file = "README.md", content-type = "text/markdown" }
+version = { attr = "nnbench.__version__" }
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.setuptools.package-data]
 nnbench = ["py.typed"]
-
-# Automatically determine version number from Git tags
-[tool.setuptools_scm]
 
 [tool.mypy]
 allow_redefinition = true

--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -1,17 +1,11 @@
 """A framework for organizing and running benchmark workloads on machine learning models."""
 
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("nnbench")
-except PackageNotFoundError:
-    # package is not installed
-    pass
-
 from .core import benchmark, parametrize, product
 from .reporter import BenchmarkReporter
 from .runner import BenchmarkRunner
 from .types import Benchmark, BenchmarkRecord, Memo, Parameters
+
+__version__ = "0.3.0"
 
 
 # TODO: This isn't great, make it functional instead?

--- a/uv.lock
+++ b/uv.lock
@@ -697,7 +697,7 @@ wheels = [
 
 [[package]]
 name = "nnbench"
-version = "0.2.1.dev38+g73e0973"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "tabulate" },


### PR DESCRIPTION
setuptools_scm has a few drawbacks to version management by hand, such as inflexibility for releasing off-tag, and missing info on shallow checkouts.

As such, revert back to a static version number, with tagged commits as version bumps.