### PR TITLE
Remove compression, support file reporting and context passing on the command line

### DIFF
--- a/docs/tutorials/duckdb.md
+++ b/docs/tutorials/duckdb.md
@@ -21,13 +21,13 @@ Running both of these benchmarks produces a benchmark record, which we can save 
 ```python
 import nnbench
 from nnbench.context import GitEnvironmentInfo
-from nnbench.reporter.file import FileIO
+from nnbench.reporter.file import FileReporter
 
 runner = nnbench.BenchmarkRunner()
 record = runner.run("benchmarks.py", params={"a": 1, "b": 1}, context=(GitEnvironmentInfo(),))
 
-fio = FileIO()
-fio.write(record, "record.json", driver="ndjson")
+file_reporter = FileReporter()
+file_reporter.write(record, "record.json", driver="ndjson")
 ```
 
 This writes a newline-delimited JSON file as `record.json` into the current directory. We choose this format because it is ideal for duckdb to work with.

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -37,12 +37,13 @@ def main() -> int:
         "--output-file",
         metavar="<file>",
         dest="outfile",
-        help="File or stream to write results to.",
+        help="File or stream to write results to, defaults to stdout.",
         default=sys.stdout,
     )
     parser.add_argument(
         "--typecheck",
         action=argparse.BooleanOptionalAction,
+        default=True,
         help="Whether or not to strictly check types of benchmark inputs.",
     )
 
@@ -54,12 +55,17 @@ def main() -> int:
             k, v = val.split("=")
         except ValueError:
             raise ValueError("context values need to be of the form <key>=<value>")
+        # TODO: Support builtin providers in the runner
         context[k] = v
 
-    record = BenchmarkRunner().run(args.benchmarks, tags=tuple(args.tags))
+    record = BenchmarkRunner(typecheck=args.typecheck).run(
+        args.benchmarks,
+        tags=tuple(args.tags),
+        context=[lambda: context],
+    )
 
     outfile = args.outfile
-    if args.outfile == sys.stdout:
+    if outfile == sys.stdout:
         reporter = BenchmarkReporter()
         reporter.display(record)
     else:

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -2,8 +2,8 @@ import argparse
 import sys
 from typing import Any
 
-from nnbench import default_reporter, default_runner
-from nnbench.reporter.file import FileIO
+from nnbench import BenchmarkReporter, BenchmarkRunner
+from nnbench.reporter.file import FileReporter
 
 
 def main() -> int:
@@ -19,7 +19,7 @@ def main() -> int:
     parser.add_argument(
         "--context",
         action="append",
-        metavar="<key>=<value>",
+        metavar="<key=value>",
         help="Additional context values giving information about the benchmark run.",
         default=list(),
     )
@@ -40,11 +40,13 @@ def main() -> int:
         help="File or stream to write results to.",
         default=sys.stdout,
     )
+    parser.add_argument(
+        "--typecheck",
+        action=argparse.BooleanOptionalAction,
+        help="Whether or not to strictly check types of benchmark inputs.",
+    )
 
     args = parser.parse_args()
-
-    runner = default_runner()
-    reporter = default_reporter()
 
     context: dict[str, Any] = {}
     for val in args.context:
@@ -54,13 +56,14 @@ def main() -> int:
             raise ValueError("context values need to be of the form <key>=<value>")
         context[k] = v
 
-    record = runner.run(args.benchmarks, tags=tuple(args.tags))
+    record = BenchmarkRunner().run(args.benchmarks, tags=tuple(args.tags))
 
     outfile = args.outfile
     if args.outfile == sys.stdout:
+        reporter = BenchmarkReporter()
         reporter.display(record)
     else:
-        f = FileIO()
+        f = FileReporter()
         f.write(record, outfile)
 
     return 0

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -1,7 +1,9 @@
 import argparse
+import sys
 from typing import Any
 
 from nnbench import default_reporter, default_runner
+from nnbench.reporter.file import FileIO
 
 
 def main() -> int:
@@ -36,8 +38,7 @@ def main() -> int:
         metavar="<file>",
         dest="outfile",
         help="File or stream to write results to.",
-        type=argparse.FileType("w"),
-        default="-",
+        default=sys.stdout,
     )
 
     args = parser.parse_args()
@@ -54,5 +55,12 @@ def main() -> int:
         context[k] = v
 
     record = runner.run(args.benchmarks, tags=tuple(args.tags))
-    reporter.display(record)
+
+    outfile = args.outfile
+    if args.outfile == sys.stdout:
+        reporter.display(record)
+    else:
+        f = FileIO()
+        f.write(record, outfile)
+
     return 0

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -30,6 +30,15 @@ def main() -> int:
         help="Only run benchmarks marked with one or more given tag(s).",
         default=tuple(),
     )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        metavar="<file>",
+        dest="outfile",
+        help="File or stream to write results to.",
+        type=argparse.FileType("w"),
+        default="-",
+    )
 
     args = parser.parse_args()
 

--- a/src/nnbench/reporter/file.py
+++ b/src/nnbench/reporter/file.py
@@ -153,7 +153,7 @@ def get_extension(f: str | os.PathLike[str] | IO) -> str:
     Given a file path or file-like object, returns file extension
     (can be the empty string, if the file has no extension).
     """
-    if isinstance(f, str | bytes | os.PathLike):
+    if isinstance(f, str | os.PathLike):
         return Path(f).suffix
     else:
         return Path(f.name).suffix
@@ -161,7 +161,7 @@ def get_extension(f: str | os.PathLike[str] | IO) -> str:
 
 def get_protocol(url: str | os.PathLike[str]) -> str:
     url = str(url)
-    parts = re.split(r"(\:\:|\://)", url, maxsplit=1)
+    parts = re.split(r"(::|://)", url, maxsplit=1)
     if len(parts) > 1:
         return parts[0]
     return "file"

--- a/src/nnbench/reporter/file.py
+++ b/src/nnbench/reporter/file.py
@@ -167,7 +167,7 @@ def get_protocol(url: str | os.PathLike[str]) -> str:
     return "file"
 
 
-class FileIO:
+class FileReporter(BenchmarkReporter):
     def read(
         self,
         file: str | os.PathLike[str] | IO[str],
@@ -294,8 +294,3 @@ class FileIO:
 
         with fd as fp:
             ser(record, fp, options or {})
-
-
-class FileReporter(FileIO, BenchmarkReporter):
-    pass
-    # TODO: Add functionality to forward written local files via fsspec.

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -144,6 +144,8 @@ class BenchmarkRunner:
             msng, *_ = missing
             raise ValueError(f"missing value for required parameter {msng!r}")
 
+        # TODO(n.junge): This doesn't pick up mistyped defaults
+        #  (admittedly, that's likely user error)
         for k, v in params.items():
             if k not in allvars:
                 warnings.warn(

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from nnbench.reporter.file import FileIO
+from nnbench.reporter.file import FileReporter
 from nnbench.types import BenchmarkRecord
 
 
@@ -12,7 +12,7 @@ from nnbench.types import BenchmarkRecord
 )
 def test_fileio_writes_no_compression_inline(tmp_path: Path, ext: str) -> None:
     """Tests data integrity for file IO roundtrips with both context modes."""
-    f = FileIO()
+    f = FileReporter()
 
     rec = BenchmarkRecord(
         context={"a": "b", "s": 1, "b.c": 1.0},


### PR DESCRIPTION
~This will be used to wire up an output to either the console or any supported file format once the interface is canonicalized.~

-----------------

This PR ended up containing a bunch of changes related to file outputs and command line usage of nnbench. Main changes are:

1) Users can now save benchmark results to files via `nnbench benchmarks.py -o record.json` (or any other supported file format).
2) Users can **also** write files directly to remote storage implementations, provided there is an fsspec implementation for it: `nnbench benchmarks.py -o s3://my-bucket/record.json` (requires fsspec and the file system implementation of choice be installed).
3) Context values are now wired into the record when passed on the command line, i.e. `nnbench benchmarks.py --context=foo=bar` creates a `"foo": "bar"` key-value pair in the record context. Support for builtin providers (or user-created ones) is still outstanding.
4) Compression was removed, but can be rolled forward again once it is clear how to wrap it around opened records (or a user actually requests it).