### PR TITLE
Add `nnbench compare` subcommand, comparison function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,11 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["tabulate", "typing-extensions; python_version< '3.11'"]
+dependencies = [
+    "rich",
+    "tabulate",
+    "typing-extensions; python_version< '3.11'",
+]
 
 dynamic = ["readme", "version"]
 

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -8,22 +8,26 @@ from nnbench.reporter.file import FileReporter
 
 def main() -> int:
     parser = argparse.ArgumentParser("nnbench")
+    subparsers = parser.add_subparsers(
+        metavar="<command>", required=False, dest="command", help="Subcommands"
+    )
+    run_parser = subparsers.add_parser("run", help="Run a benchmark workload.")
     # can be a directory, single file, or glob
-    parser.add_argument(
+    run_parser.add_argument(
         "benchmarks",
         nargs="?",
         metavar="<benchmarks>",
         help="Python file or directory of files containing benchmarks to run.",
         default="benchmarks",
     )
-    parser.add_argument(
+    run_parser.add_argument(
         "--context",
         action="append",
         metavar="<key=value>",
         help="Additional context values giving information about the benchmark run.",
         default=list(),
     )
-    parser.add_argument(
+    run_parser.add_argument(
         "-t",
         "--tag",
         action="append",
@@ -32,7 +36,7 @@ def main() -> int:
         help="Only run benchmarks marked with one or more given tag(s).",
         default=tuple(),
     )
-    parser.add_argument(
+    run_parser.add_argument(
         "-o",
         "--output-file",
         metavar="<file>",
@@ -40,36 +44,87 @@ def main() -> int:
         help="File or stream to write results to, defaults to stdout.",
         default=sys.stdout,
     )
-    parser.add_argument(
+    run_parser.add_argument(
         "--typecheck",
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Whether or not to strictly check types of benchmark inputs.",
     )
 
-    args = parser.parse_args()
-
-    context: dict[str, Any] = {}
-    for val in args.context:
-        try:
-            k, v = val.split("=")
-        except ValueError:
-            raise ValueError("context values need to be of the form <key>=<value>")
-        # TODO: Support builtin providers in the runner
-        context[k] = v
-
-    record = BenchmarkRunner(typecheck=args.typecheck).run(
-        args.benchmarks,
-        tags=tuple(args.tags),
-        context=[lambda: context],
+    compare_parser = subparsers.add_parser(
+        "compare", help="Compare results from multiple benchmark runs."
     )
+    compare_parser.add_argument(
+        "records",
+        nargs="+",
+        help="Records to compare results for. Can be given as local files or remote URIs.",
+    )
+    compare_parser.add_argument(
+        "-P",
+        "--include-parameter",
+        action="append",
+        metavar="<name>",
+        dest="parameters",
+        default=list(),
+        help="Names of input parameters to display in the comparison table.",
+    )
+    compare_parser.add_argument(
+        "-C",
+        "--include-context",
+        action="append",
+        metavar="<name>",
+        dest="contextvals",
+        default=list(),
+        help="Context values to display in the comparison table. Use dotted syntax for nested context values.",
+    )
+    compare_parser.add_argument(
+        "-E",
+        "--extra-column",
+        action="append",
+        metavar="<name>",
+        dest="extra_cols",
+        default=list(),
+        help="Additional record data to display in the comparison table.",
+    )
+    # TODO: Add customization option for rich table displays
 
-    outfile = args.outfile
-    if outfile == sys.stdout:
-        reporter = BenchmarkReporter()
-        reporter.display(record)
-    else:
-        f = FileReporter()
-        f.write(record, outfile)
+    try:
+        args = parser.parse_args()
+        if args.command == "run":
+            context: dict[str, Any] = {}
+            for val in args.context:
+                try:
+                    k, v = val.split("=")
+                except ValueError:
+                    raise ValueError("context values need to be of the form <key>=<value>")
+                # TODO: Support builtin providers in the runner
+                context[k] = v
 
-    return 0
+            record = BenchmarkRunner(typecheck=args.typecheck).run(
+                args.benchmarks,
+                tags=tuple(args.tags),
+                context=[lambda: context],
+            )
+
+            outfile = args.outfile
+            if outfile == sys.stdout:
+                reporter = BenchmarkReporter()
+                reporter.display(record)
+            else:
+                f = FileReporter()
+                f.write(record, outfile)
+        elif args.command == "compare":
+            from nnbench.compare import compare
+
+            f = FileReporter()
+            records = [f.read(file) for file in args.records]
+            compare(
+                records=records,
+                parameters=args.parameters,
+                contextvals=args.contextvals,
+            )
+
+        return 0
+    except Exception as e:
+        sys.stderr.write(f"error: {e}")
+        sys.exit(1)

--- a/src/nnbench/compare.py
+++ b/src/nnbench/compare.py
@@ -1,0 +1,75 @@
+import copy
+from collections.abc import Sequence
+
+from rich.console import Console
+from rich.table import Table
+
+from nnbench.types import BenchmarkRecord
+from nnbench.util import flatten
+
+_MISSING = "-----"
+
+
+def get_value_by_name(record: BenchmarkRecord, name: str, missing: str) -> str:
+    metric_names = [b["name"] for b in record.benchmarks]
+    if name not in metric_names:
+        return missing
+
+    res = record.benchmarks[metric_names.index(name)]
+    if res.get("error_occurred", False):
+        errmsg = res.get("error_message", "<unknown>")
+        return "[red]ERROR: [/red]" + errmsg
+    return str(res.get("value", missing))
+
+
+def compare(
+    records: Sequence[BenchmarkRecord],
+    parameters: Sequence[str] | None = None,
+    contextvals: Sequence[str] | None = None,
+    missing: str = _MISSING,
+) -> None:
+    t = Table()
+
+    rows: list[list[str]] = []
+    columns: list[str] = []
+
+    # Add metric names first, without duplicates.
+    for record in records:
+        names = [b["name"] for b in record.benchmarks]
+        for name in names:
+            if name not in set(columns):
+                columns.append(name)
+
+    names = copy.deepcopy(columns)
+
+    # Then parameters, if any
+    if parameters is not None:
+        columns += [f"Params->{p}" for p in parameters]
+
+    if contextvals is not None:
+        columns += contextvals
+
+    # Main loop, extracts values from the individual records,
+    # or a placeholder if there are any.
+    for record in records:
+        # TODO: Add record-level run name, extract
+        # flatten facilitates dotted access to nested context values, e.g. git.branch
+        ctx = flatten(record.context)
+        row = [get_value_by_name(record, name, _MISSING) for name in names]
+        # hacky, extra cols is likely now broken
+        b = record.benchmarks[0]
+        # TODO: Add record-level parameters struct as the union of all benchmark inputs
+        if parameters is not None:
+            params = b.get("parameters", {})
+            row += [str(params.get(p)) for p in parameters]
+        if contextvals is not None:
+            row += [str(ctx.get(cval, missing)) for cval in contextvals]
+        rows.append(row)
+
+    for column in columns:
+        t.add_column(column)
+    for row in rows:
+        t.add_row(*row)
+
+    c = Console()
+    c.print(t)

--- a/uv.lock
+++ b/uv.lock
@@ -700,6 +700,7 @@ name = "nnbench"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
+    { name = "rich" },
     { name = "tabulate" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -748,6 +749,7 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'dev'" },
     { name = "pyarrow", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
+    { name = "rich" },
     { name = "tabulate" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]


### PR DESCRIPTION
Works using metric (benchmark) names as columns, and records as lines. Alternatively, we could support metrics as rows and record IDs as columns in the future.

Contains logic to add parameter values and context values to the table as columns, also directly on the command line. In the future, we could make a comparison class that can be subclassed to avoid option clutter on the command line for customizing the rich table display.