### PR TITLE
Some tweaks related to context ingestion

### DIFF
--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -3,7 +3,7 @@ import sys
 from typing import Any
 
 from nnbench import BenchmarkRunner, ConsoleReporter, __version__
-from nnbench.reporter.file import FileReporter
+from nnbench.reporter import FileReporter
 
 _VERSION = f"%(prog)s version {__version__}"
 
@@ -122,7 +122,6 @@ def main() -> int:
         default=list(),
         help="Additional record data to display in the comparison table.",
     )
-    # TODO: Add customization option for rich table displays
 
     try:
         args = parser.parse_args()
@@ -130,10 +129,9 @@ def main() -> int:
             context: dict[str, Any] = {}
             for val in args.context:
                 try:
-                    k, v = val.split("=")
+                    k, v = val.split("=", 1)
                 except ValueError:
                     raise ValueError("context values need to be of the form <key>=<value>")
-                # TODO: Support builtin providers in the runner
                 context[k] = v
 
             record = BenchmarkRunner(typecheck=args.typecheck).run(
@@ -159,8 +157,7 @@ def main() -> int:
                 parameters=args.parameters,
                 contextvals=args.contextvals,
             )
-
         return 0
     except Exception as e:
         sys.stderr.write(f"error: {e}")
-        sys.exit(1)
+        return 1

--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -29,14 +29,14 @@ class PythonInfo:
 
     Parameters
     ----------
-    *packages: str
+    packages: tuple[str, ...]
         Names of the requested packages under which they exist in the current environment.
         For packages installed through ``pip``, this equals the PyPI package name.
     """
 
     key = "python"
 
-    def __init__(self, *packages: str):
+    def __init__(self, packages: tuple[str, ...]):
         self.packages = packages
 
     def __call__(self) -> dict[str, Any]:
@@ -191,5 +191,4 @@ class CPUInfo:
         # result is in bytes, so no need for base conversion.
         result["total_memory"] = mem_struct.total / mem_conversion
         result["memory_unit"] = self.memunit
-        # TODO: Lacks CPU cache info, which requires a solution other than psutil.
         return {self.key: result}


### PR DESCRIPTION
Unfortunately, the first prototype for builtin context provider support from the command line was not successful.

The alternative is to provide values as
key=`from nnbench.context import xy; print(xy()())`, but that returns the serialized JSON struct, which is not all that useful. Maybe we can get around that by optionally processing JSON-like values into the context.