### PR TITLE
Add run name to benchmark record

### DIFF
--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -15,6 +15,7 @@ def test_fileio_writes_no_compression_inline(tmp_path: Path, ext: str) -> None:
     f = FileReporter()
 
     rec = BenchmarkRecord(
+        name="my-run",
         context={"a": "b", "s": 1, "b.c": 1.0},
         benchmarks=[{"name": "foo", "value": 1}, {"name": "bar", "value": 2}],
     )


### PR DESCRIPTION
This enables the user to specify names for their experiments, and gives a good primary key for database dumps of benchmarks (upcoming).

Closes #169.