### PR TITLE
Simplify JSON representation computation facility

### DIFF
--- a/src/nnbench/types/benchmark.py
+++ b/src/nnbench/types/benchmark.py
@@ -29,7 +29,7 @@ def NoOp(state: State, params: Mapping[str, Any] = MappingProxyType({})) -> None
 
 @dataclass(frozen=True)
 class BenchmarkRecord:
-    name: str
+    run: str
     context: dict[str, Any]
     benchmarks: list[dict[str, Any]]
 
@@ -53,7 +53,7 @@ class BenchmarkRecord:
         for b in self.benchmarks:
             bc = copy.deepcopy(b)
             bc["context"] = self.context
-            bc["run-name"] = self.name
+            bc["run"] = self.run
             results.append(bc)
         return results
 
@@ -82,20 +82,20 @@ class BenchmarkRecord:
 
             benchmarks = bms["benchmarks"]
             context = bms.get("context", {})
-            name = bms.get("name", "")
+            run = bms.get("run", "")
         else:
-            name = ""
+            run = ""
             context = {}
             benchmarks = bms
             for b in benchmarks:
                 # TODO(nicholasjng): This does not do the right thing if the list contains
                 #  data from multiple benchmark runs, e.g. from a DB query.
-                if "run-name" in b:
-                    name = b.pop("run-name")
+                if "run" in b:
+                    run = b.pop("run")
                 if "context" in b:
                     # TODO: Log context key/value disagreements
                     context |= b.pop("context", {})
-        return cls(name=name, benchmarks=benchmarks, context=context)
+        return cls(run=run, benchmarks=benchmarks, context=context)
 
 
 @dataclass(frozen=True)

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -15,7 +15,7 @@ def test_fileio_writes_no_compression_inline(tmp_path: Path, ext: str) -> None:
     f = FileReporter()
 
     rec = BenchmarkRecord(
-        name="my-run",
+        run="my-run",
         context={"a": "b", "s": 1, "b.c": 1.0},
         benchmarks=[{"name": "foo", "value": 1}, {"name": "bar", "value": 2}],
     )


### PR DESCRIPTION
Also changes the BenchmarkRecord run name key to "run" in the dataclass and JSON documents to break ambiguity.