### PR TITLE
Add TOML config parsing stub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "rich",
     "tomli >= 1.1.0 ; python_version < '3.11'",
-    "typing-extensions; python_version< '3.11'",
+    "typing-extensions; python_version < '3.11'",
 ]
 
 dynamic = ["readme", "version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,11 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["rich", "typing-extensions; python_version< '3.11'"]
+dependencies = [
+    "rich",
+    "tomli >= 1.1.0 ; python_version < '3.11'",
+    "typing-extensions; python_version< '3.11'",
+]
 
 dynamic = ["readme", "version"]
 

--- a/src/nnbench/config.py
+++ b/src/nnbench/config.py
@@ -1,4 +1,6 @@
+import os
 import sys
+from typing import Any
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -6,7 +8,9 @@ else:
     import tomli as tomllib
 
 
-def parse_nnbench_config(pyproject_path):
+# TODO: It's not just Any in the return, but a few well-defined context keys -
+# put some effort into parsing them
+def parse_nnbench_config(pyproject_path: str | os.PathLike[str]) -> dict[str, Any]:
     with open(pyproject_path, "rb") as fp:
         config = tomllib.load(fp)
 

--- a/src/nnbench/config.py
+++ b/src/nnbench/config.py
@@ -1,5 +1,9 @@
+"""Utilities for parsing an nnbench config block out of a pyproject.toml."""
+
+import logging
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
 if sys.version_info >= (3, 11):
@@ -7,11 +11,31 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+logger = logging.getLogger("nnbench.config")
+
+
+def locate_pyproject() -> os.PathLike[str]:
+    cwd = Path.cwd()
+    for p in (cwd, *cwd.parents):
+        if (pyproject_cand := (p / "pyproject.toml")).exists():
+            return pyproject_cand
+        if p == Path.home():
+            break
+    raise RuntimeError("could not locate pyproject.toml")
+
 
 # TODO: It's not just Any in the return, but a few well-defined context keys -
 # put some effort into parsing them
-def parse_nnbench_config(pyproject_path: str | os.PathLike[str]) -> dict[str, Any]:
+def parse_nnbench_config(pyproject_path: str | os.PathLike[str] | None = None) -> dict[str, Any]:
+    if pyproject_path is None:
+        try:
+            pyproject_path = locate_pyproject()
+        except RuntimeError:
+            # TODO: This should hold sensible default values for all top-level keys,
+            # preferably as a dataclass.
+            # pyproject.toml cannot be found, so return an empty config.
+            return {"log-level": "NOTSET"}
+
     with open(pyproject_path, "rb") as fp:
         config = tomllib.load(fp)
-
     return config.get("tool", {}).get("nnbench", {})

--- a/src/nnbench/config.py
+++ b/src/nnbench/config.py
@@ -10,4 +10,4 @@ def parse_nnbench_config(pyproject_path):
     with open(pyproject_path, "rb") as fp:
         config = tomllib.load(fp)
 
-    return config.get("tool.nnbench", {})
+    return config.get("tool", {}).get("nnbench", {})

--- a/src/nnbench/config.py
+++ b/src/nnbench/config.py
@@ -1,0 +1,13 @@
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+def parse_nnbench_config(pyproject_path):
+    with open(pyproject_path, "rb") as fp:
+        config = tomllib.load(fp)
+
+    return config.get("tool.nnbench", {})

--- a/src/nnbench/config.py
+++ b/src/nnbench/config.py
@@ -3,15 +3,43 @@
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 if sys.version_info >= (3, 11):
+    from typing import Self
+
     import tomllib
 else:
     import tomli as tomllib
+    from typing_extensions import Self
 
 logger = logging.getLogger("nnbench.config")
+
+
+@dataclass
+class ContextProviderDef:
+    name: str
+    classpath: str
+    arguments: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class nnbenchConfig:
+    log_level: str
+    context: list[ContextProviderDef]
+
+    @classmethod
+    def empty(cls) -> Self:
+        return cls(log_level="NOTSET", context=[])
+
+    @classmethod
+    def from_toml(cls, d: dict[str, Any]) -> Self:
+        provider_map = d.get("context", {})
+        context = [ContextProviderDef(**cpd) for cpd in provider_map.values()]
+        log_level = d.get("log-level", "NOTSET")
+        return cls(log_level=log_level, context=context)
 
 
 def locate_pyproject() -> os.PathLike[str]:
@@ -24,18 +52,15 @@ def locate_pyproject() -> os.PathLike[str]:
     raise RuntimeError("could not locate pyproject.toml")
 
 
-# TODO: It's not just Any in the return, but a few well-defined context keys -
-# put some effort into parsing them
-def parse_nnbench_config(pyproject_path: str | os.PathLike[str] | None = None) -> dict[str, Any]:
+def parse_nnbench_config(pyproject_path: str | os.PathLike[str] | None = None) -> nnbenchConfig:
     if pyproject_path is None:
         try:
             pyproject_path = locate_pyproject()
         except RuntimeError:
-            # TODO: This should hold sensible default values for all top-level keys,
-            # preferably as a dataclass.
             # pyproject.toml cannot be found, so return an empty config.
-            return {"log-level": "NOTSET"}
+            return nnbenchConfig.empty()
 
     with open(pyproject_path, "rb") as fp:
-        config = tomllib.load(fp)
-    return config.get("tool", {}).get("nnbench", {})
+        pyproject_cfg = tomllib.load(fp)
+    nnbench_cfg = pyproject_cfg.get("tool", {}).get("nnbench", {})
+    return nnbenchConfig.from_toml(nnbench_cfg)

--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -2,7 +2,7 @@
 
 import platform
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
 ContextProvider = Callable[[], dict[str, Any]]
@@ -29,14 +29,14 @@ class PythonInfo:
 
     Parameters
     ----------
-    *packages: str
+    packages: str
         Names of the requested packages under which they exist in the current environment.
         For packages installed through ``pip``, this equals the PyPI package name.
     """
 
     key = "python"
 
-    def __init__(self, *packages: str):
+    def __init__(self, packages: Sequence[str] = ()):
         self.packages = packages
 
     def __call__(self) -> dict[str, Any]:
@@ -57,7 +57,7 @@ class PythonInfo:
             except PackageNotFoundError:
                 dependencies[pkg] = ""
 
-        result["dependencies"] = dependencies
+        result["packages"] = dependencies
         return {self.key: result}
 
 
@@ -193,3 +193,6 @@ class CPUInfo:
         result["memory_unit"] = self.memunit
         # TODO: Lacks CPU cache info, which requires a solution other than psutil.
         return {self.key: result}
+
+
+builtin_providers: dict[str, ContextProvider] = {"cpu": CPUInfo(), "python": PythonInfo()}

--- a/src/nnbench/reporter/console.py
+++ b/src/nnbench/reporter/console.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 from rich.console import Console
@@ -46,8 +47,8 @@ class ConsoleReporter(BenchmarkReporter):
         columns: list[str] = ["Benchmark", "Value", "Wall time (ns)", "Parameters"]
 
         # print context values
-        for k, v in record.context.items():
-            print(f"{k}: {v}")
+        print("Context values:")
+        print(json.dumps(record.context, indent=4))
 
         for bm in record.benchmarks:
             row = [bm["name"], get_value_by_name(bm), str(bm["time_ns"]), str(bm["parameters"])]

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -22,7 +22,7 @@ from nnbench.types import Benchmark, BenchmarkRecord, Parameters, State
 from nnbench.types.memo import is_memo, is_memo_type
 from nnbench.util import import_file_as_module, ismodule
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("nnbench.runner")
 
 
 def qualname(fn: Callable) -> str:
@@ -134,6 +134,7 @@ class BenchmarkRunner:
                 self.collect(py, tags)
             return
         elif ppath.is_file():
+            logger.debug(f"Collecting benchmarks from file {ppath}.")
             module = import_file_as_module(path_or_module)
         elif ismodule(path_or_module):
             module = sys.modules[str(path_or_module)]

--- a/uv.lock
+++ b/uv.lock
@@ -701,6 +701,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
@@ -749,6 +750,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 


### PR DESCRIPTION
Contains version-aware stubs for importing a standard-library TOML parser for Python 3.10+ (our support matrix).

Next, we will parse out `tool.nnbench` fields, validate their structure, and instantiate different types of command classes from there.

Working towards #159.