### PR TITLE
Add API docs for all direct `nnbench` submodules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,13 @@ repos:
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --explicit-package-bases]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.8.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.4
+    rev: 0.5.5
     hooks:
       - id: uv-lock
         name: Lock project dependencies

--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -6,12 +6,3 @@ from .runner import BenchmarkRunner
 from .types import Benchmark, BenchmarkRecord, Memo, Parameters
 
 __version__ = "0.3.0"
-
-
-# TODO: This isn't great, make it functional instead?
-def default_runner() -> BenchmarkRunner:
-    return BenchmarkRunner()
-
-
-def default_reporter() -> BenchmarkReporter:
-    return ConsoleReporter()

--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -1,7 +1,7 @@
 """A framework for organizing and running benchmark workloads on machine learning models."""
 
 from .core import benchmark, parametrize, product
-from .reporter import BenchmarkReporter, ConsoleReporter
+from .reporter import BenchmarkReporter, ConsoleReporter, FileReporter
 from .runner import BenchmarkRunner
 from .types import Benchmark, BenchmarkRecord, Memo, Parameters
 

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -185,7 +185,7 @@ def main() -> int:
                 builtin_providers[p.name] = klass(**p.arguments)
             for val in args.context:
                 try:
-                    k, v = val.split("=")
+                    k, v = val.split("=", 1)
                 except ValueError:
                     raise ValueError("context values need to be of the form <key>=<value>")
                 if k == "provider":

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -1,3 +1,5 @@
+"""The ``nnbench`` command line interface."""
+
 import argparse
 import importlib
 import logging
@@ -163,7 +165,7 @@ def construct_parser(config: nnbenchConfig) -> argparse.ArgumentParser:
 
 
 def main() -> int:
-    """The main nnbench CLI entry point."""
+    """The main ``nnbench`` CLI entry point."""
     config = parse_nnbench_config()
     parser = construct_parser(config)
     try:

--- a/src/nnbench/compare.py
+++ b/src/nnbench/compare.py
@@ -1,3 +1,5 @@
+"""Contains machinery to compare multiple benchmark records side by side."""
+
 import copy
 from collections.abc import Sequence
 
@@ -11,6 +13,30 @@ _MISSING = "-----"
 
 
 def get_value_by_name(record: BenchmarkRecord, name: str, missing: str) -> str:
+    """
+    Get the value of a metric by name from a benchmark record, or a placeholder
+    if the metric name is not present in the record.
+
+    If the name is found, but the benchmark did not complete successfully
+    (i.e. the ``error_occurred`` value is set to ``True``), the returned value
+    will be set to the value of the ``error_message`` field.
+
+    Parameters
+    ----------
+    record: BenchmarkRecord
+        The benchmark record to extract a metric value from.
+    name: str
+        The name of the target metric.
+    missing: str
+        A placeholder string to return in the event of a missing metric.
+
+    Returns
+    -------
+    str
+        A string containing the metric value (or error message) formatted
+        as rich text.
+
+    """
     metric_names = [b["name"] for b in record.benchmarks]
     if name not in metric_names:
         return missing
@@ -28,6 +54,22 @@ def compare(
     contextvals: Sequence[str] | None = None,
     missing: str = _MISSING,
 ) -> None:
+    """
+    Compare a series of benchmark records, displaying their results in a table
+    side by side.
+
+    Parameters
+    ----------
+    records: Sequence[BenchmarkRecord]
+        The benchmark records to compare.
+    parameters: Sequence[str] | None
+        Names of parameters to display as extra columns.
+    contextvals: Sequence[str] | None
+        Names of context values to display as extra columns. Supports nested access
+        via dotted syntax.
+    missing: str
+        A placeholder string to show in the event of a missing metric.
+    """
     t = Table()
 
     rows: list[list[str]] = []

--- a/src/nnbench/config.py
+++ b/src/nnbench/config.py
@@ -1,4 +1,4 @@
-"""Utilities for parsing an nnbench config block out of a pyproject.toml."""
+"""Utilities for parsing an nnbench config block out of a pyproject.toml file."""
 
 import logging
 import os
@@ -20,22 +20,50 @@ logger = logging.getLogger("nnbench.config")
 
 @dataclass
 class ContextProviderDef:
+    """
+    A POD struct representing a custom context provider definition in a
+    pyproject.toml table.
+    """
+
     name: str
+    """Name under which the provider should be registered by nnbench."""
     classpath: str
+    """Full path to the class or callable returning the context dict."""
     arguments: dict[str, Any]
+    """Arguments needed to instantiate the context provider class,
+    given as key-value pairs in the table."""
 
 
 @dataclass(frozen=True)
 class nnbenchConfig:
     log_level: str
+    """Log level to use for the ``nnbench`` module root logger."""
     context: list[ContextProviderDef]
+    """A list of context provider definitions found in pyproject.toml."""
 
     @classmethod
     def empty(cls) -> Self:
+        """An empty default config, returned if no pyproject.toml is found."""
         return cls(log_level="NOTSET", context=[])
 
     @classmethod
     def from_toml(cls, d: dict[str, Any]) -> Self:
+        """
+        Returns an nnbench CLI config by parsing a [tool.nnbench] block from a
+        pyproject.toml file.
+
+        Parameters
+        ----------
+        d: dict[str, Any]
+            Mapping containing the [tool.nnbench] block as obtained by
+            ``tomllib.load``.
+
+        Returns
+        -------
+        Self
+            An nnbench config instance with the values from pyproject.toml,
+            with defaults for values that were not set explicitly.
+        """
         provider_map = d.get("context", {})
         context = [ContextProviderDef(**cpd) for cpd in provider_map.values()]
         log_level = d.get("log-level", "NOTSET")
@@ -43,6 +71,19 @@ class nnbenchConfig:
 
 
 def locate_pyproject() -> os.PathLike[str]:
+    """
+    Locate a pyproject.toml file by walking up from the current directory,
+    and checking for file existence, stopping at the current user home
+    directory.
+
+    If no pyproject.toml file can be found, a RuntimeError is raised.
+
+    Returns
+    -------
+    os.PathLike[str]
+        The path to pyproject.toml.
+
+    """
     cwd = Path.cwd()
     for p in (cwd, *cwd.parents):
         if (pyproject_cand := (p / "pyproject.toml")).exists():
@@ -53,6 +94,23 @@ def locate_pyproject() -> os.PathLike[str]:
 
 
 def parse_nnbench_config(pyproject_path: str | os.PathLike[str] | None = None) -> nnbenchConfig:
+    """
+    Load an nnbench config from a given pyproject.toml file.
+
+    If no path to the pyproject.toml file is given, an attempt at autodiscovery
+    will be made. If that is unsuccessful, an empty config is returned.
+
+    Parameters
+    ----------
+    pyproject_path: str | os.PathLike[str] | None
+        Path to the current project's pyproject.toml file, optional.
+
+    Returns
+    -------
+    nnbenchConfig
+        The loaded config if found, or a default config.
+
+    """
     if pyproject_path is None:
         try:
             pyproject_path = locate_pyproject()

--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -50,14 +50,14 @@ class PythonInfo:
         result["buildno"] = buildno
         result["buildtime"] = buildtime
 
-        dependencies: dict[str, str] = {}
+        packages: dict[str, str] = {}
         for pkg in self.packages:
             try:
-                dependencies[pkg] = version(pkg)
+                packages[pkg] = version(pkg)
             except PackageNotFoundError:
-                dependencies[pkg] = ""
+                packages[pkg] = ""
 
-        result["packages"] = dependencies
+        result["packages"] = packages
         return {self.key: result}
 
 
@@ -140,6 +140,20 @@ class GitEnvironmentInfo:
 
 
 class CPUInfo:
+    """
+    A context helper providing information about the host machine's CPU
+    capabilities, operating system, and amount of memory.
+
+    Parameters
+    ----------
+    memunit: Literal["kB", "MB", "GB"]
+        The unit to display memory size in (either "kB" for kilobytes,
+        "MB" for Megabytes, or "GB" for Gigabytes).
+    frequnit: Literal["kHz", "MHz", "GHz"]
+        The unit to display CPU clock speeds in (either "kHz" for kilohertz,
+        "MHz" for Megahertz, or "GHz" for Gigahertz).
+    """
+
     key = "cpu"
 
     def __init__(

--- a/src/nnbench/fixtures.py
+++ b/src/nnbench/fixtures.py
@@ -1,3 +1,8 @@
+"""
+Collect values ('fixtures') by name for benchmark runs from certain files,
+similarly to pytest and its ``conftest.py``.
+"""
+
 import inspect
 import os
 from collections.abc import Callable, Iterable

--- a/src/nnbench/fixtures.py
+++ b/src/nnbench/fixtures.py
@@ -39,19 +39,25 @@ class FixtureManager:
     A lean class responsible for resolving parameter values (aka 'fixtures')
     of benchmarks from provider functions.
 
-    To resolve a benchmark parameter (in resolve()), the class does
-    the following:
+    To resolve a benchmark parameter (in ``FixtureManager.resolve()``), the class
+    does the following:
+
         1. Obtain the path to the file containing the benchmark, as
-         the __file__ attribute of the benchmark function's origin module.
+        the ``__file__`` attribute of the benchmark function's origin module.
+
         2. Look for a `conf.py` file in the same directory.
+
         3. Import the `conf.py` module, look for a function named the same as
-         the benchmark parameter.
+        the benchmark parameter.
+
         4. If necessary, resolve any named inputs to the function **within**
-         the module scope.
+        the module scope.
+
         5. If no function member is found, and the benchmark file is not in `root`,
-         fall back to the parent directory, repeat steps 2-5, until `root` is reached.
+        fall back to the parent directory, repeat steps 2-5, until `root` is reached.
+
         6. If no `conf.py` contains any function matching the name, throw an
-         error (TODO: ImportError? custom?)
+        error.
     """
 
     def __init__(self, root: str | os.PathLike[str]) -> None:
@@ -65,10 +71,22 @@ class FixtureManager:
 
     def collect(self, mod: ModuleType, names: Iterable[str]) -> dict[str, Any]:
         """
-        Given a fixture module and a list of fixture names required (for a
+        Given a module containing fixtures (contents of a ``conf.py`` file imported
+        as a module), and a list of required fixture names (for a
         selected benchmark), collect values, computing transitive closures in the
-        meantime (i.e., inputs required to compute certain fixtures), and add
-        the resulting values to the cache.
+        process (i.e., all inputs required to compute the set of fixtures).
+
+        Parameters
+        ----------
+        mod: ModuleType
+            The module to import fixture values from.
+        names: Iterable[str]
+            Names of fixture values to compute and use in the invoking benchmark.
+
+        Returns
+        -------
+        dict[str, Any]
+            The mapping of fixture names to their values.
         """
         res: dict[str, Any] = {}
         for name in names:
@@ -100,6 +118,25 @@ class FixtureManager:
         return res
 
     def resolve(self, bm: Benchmark) -> dict[str, Any]:
+        """
+        Resolve fixture values for a benchmark.
+
+        Fixtures will be resolved only for benchmark inputs that do not have a
+        default value in place in the interface.
+
+        Fixtures need to be functions in a ``conf.py`` module in the benchmark
+        directory structure, and must *exactly* match input parameters by name.
+
+        Parameters
+        ----------
+        bm: Benchmark
+            The benchmark to resolve fixtures for.
+
+        Returns
+        -------
+        dict[str, Any]
+            The mapping of fixture values to use for the given benchmark.
+        """
         fixturevals: dict[str, Any] = {}
         # first, get the candidate fixture names, aka the benchmark param names.
         # We limit ourselves to names that do not have a default value.

--- a/src/nnbench/reporter/__init__.py
+++ b/src/nnbench/reporter/__init__.py
@@ -1,5 +1,6 @@
 """
-A lightweight interface for refining, displaying, and streaming benchmark results to various sinks.
+An interface for displaying, writing, or streaming benchmark results to
+files, databases, or web services.
 """
 
 from .base import BenchmarkReporter

--- a/src/nnbench/reporter/console.py
+++ b/src/nnbench/reporter/console.py
@@ -20,21 +20,34 @@ def get_value_by_name(result: dict[str, Any]) -> str:
 class ConsoleReporter(BenchmarkReporter):
     """
     The base interface for a console reporter class.
+
+    Wraps a ``rich.Console()`` to display values in a rich-text table.
     """
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialize a console reporter.
+
+        Parameters
+        ----------
+        *args: Any
+            Positional arguments, unused.
+        **kwargs: Any
+            Keyword arguments, forwarded directly to ``rich.Console()``.
+        """
         super().__init__(*args, **kwargs)
         # TODO: Add context manager to register live console prints
         self.console = Console(**kwargs)
 
     def display(self, record: BenchmarkRecord) -> None:
         """
-        Display a benchmark record in the console.
+        Display a benchmark record in the console as a rich-text table.
 
-        Benchmarks and context values will be filtered before display
-        if any filtering is applied.
+        Gives a summary of all present context values directly above the table,
+        as a pretty-printed JSON record.
 
-        Columns that do not contain any useful information are omitted by default.
+        By default, displays only the benchmark name, value, execution wall time,
+        and parameters.
 
         Parameters
         ----------

--- a/src/nnbench/reporter/file.py
+++ b/src/nnbench/reporter/file.py
@@ -10,8 +10,8 @@ from nnbench.types import BenchmarkRecord
 
 _Options = dict[str, Any]
 SerDe = tuple[
-    Callable[[BenchmarkRecord, IO, dict[str, Any]], None],
-    Callable[[IO, dict[str, Any]], BenchmarkRecord],
+    Callable[[BenchmarkRecord, IO, _Options], None],
+    Callable[[IO, _Options], BenchmarkRecord],
 ]
 
 
@@ -183,9 +183,10 @@ class FileReporter(BenchmarkReporter):
         Parameters
         ----------
         file: str | os.PathLike[str] | IO[str]
-            The file name to read from.
+            The file name, or object, to read from.
         mode: str
-            File mode to use. Can be any of the modes used in builtin ``open()``.
+            Mode to use when opening a new file from a path.
+            Can be any of the read modes supported by built-in ``open()``.
         driver: str | None
             File driver implementation to use. If None, the file driver inferred from the
             given file path's extension will be used.
@@ -251,9 +252,10 @@ class FileReporter(BenchmarkReporter):
         record: BenchmarkRecord
             The record to write to the database.
         file: str | os.PathLike[str]
-            The file name to write to.
+            The file name, or object, to write to.
         mode: str
-            File mode to use. Can be any of the modes used in builtin ``open()``.
+            Mode to use when opening a new file from a path.
+            Can be any of the write modes supported by built-in ``open()``.
         driver: str | None
             File driver implementation to use. If None, the file driver inferred from the
             given file path's extension will be used.
@@ -266,6 +268,7 @@ class FileReporter(BenchmarkReporter):
             If no registered file driver matches the file extension and no other driver
             was explicitly specified.
         """
+        # TODO: Guard against file
         driver = driver or get_extension(file)
 
         if not driver:

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -45,9 +45,12 @@ class BenchmarkRunner:
     """
     An abstract benchmark runner class.
 
-    Collects benchmarks from a module or file using the collect() method.
-    Runs a previously collected benchmark workload with parameters in the run() method,
-    outputting the results to a JSON-like document.
+    Collects benchmarks from a module or file using the ``BenchmarkRunner.collect()``
+    method.
+
+    Runs a previously collected benchmark workload with parameters in the
+    ``BenchmarkRunner.run()`` method, outputting the results to a
+    ``BenchmarkRecord`` dataclass.
     """
 
     benchmark_type = Benchmark

--- a/src/nnbench/types/__init__.py
+++ b/src/nnbench/types/__init__.py
@@ -1,3 +1,5 @@
+"""Custom types defined by ``nnbench`` for benchmarking workloads."""
+
 from .benchmark import Benchmark, BenchmarkRecord, Parameters, State
 from .interface import Interface
 from .memo import Memo, cached_memo

--- a/src/nnbench/types/benchmark.py
+++ b/src/nnbench/types/benchmark.py
@@ -1,4 +1,4 @@
-"""Type interfaces for benchmarks and benchmark collections."""
+"""Types for benchmarks and records holding results of a run."""
 
 import copy
 import sys

--- a/src/nnbench/types/benchmark.py
+++ b/src/nnbench/types/benchmark.py
@@ -17,6 +17,14 @@ from nnbench.types.interface import Interface
 
 @dataclass(frozen=True)
 class State:
+    """
+    A dataclass holding some basic information about a benchmark and its hierarchy
+    inside its *family* (i.e. a series of the same benchmark for different parameters).
+
+    For benchmarks registered with ``@nnbench.benchmark``, meaning no parametrization,
+    each benchmark constitutes its own family, and ``family_size == 1`` holds true.
+    """
+
     name: str
     family: str
     family_size: int
@@ -24,14 +32,23 @@ class State:
 
 
 def NoOp(state: State, params: Mapping[str, Any] = MappingProxyType({})) -> None:
+    """A no-op setup/teardown callback that does nothing."""
     pass
 
 
 @dataclass(frozen=True)
 class BenchmarkRecord:
+    """
+    A dataclass representing the result of a benchmark run, i.e. the return value
+    of a call to ``BenchmarkRunner.run()``.
+    """
+
     run: str
+    """A name describing the run."""
     context: dict[str, Any]
+    """A map of key-value pairs describing context information around the benchmark run."""
     benchmarks: list[dict[str, Any]]
+    """The list of benchmark results, each given as a Python dictionary."""
 
     def to_json(self) -> dict[str, Any]:
         """
@@ -47,7 +64,7 @@ class BenchmarkRecord:
     def to_list(self) -> list[dict[str, Any]]:
         """
         Export a benchmark record to a list of individual results,
-        each with the benchmark context inlined.
+        each with the benchmark run name and context inlined.
         """
         results = []
         for b in self.benchmarks:
@@ -72,8 +89,7 @@ class BenchmarkRecord:
         Returns
         -------
         BenchmarkRecord
-            The resulting record with the context extracted.
-
+            The resulting record, with the context and run name extracted.
         """
         context: dict[str, Any]
         if isinstance(bms, dict):
@@ -102,32 +118,22 @@ class BenchmarkRecord:
 class Benchmark:
     """
     Data model representing a benchmark. Subclass this to define your own custom benchmark.
-
-    Parameters
-    ----------
-    fn: Callable[..., Any]
-        The function defining the benchmark.
-    name: str | None
-        A name to display for the given benchmark. If not given, will be constructed from the
-        function name and given parameters.
-    params: dict[str, Any]
-        A partial parametrization to apply to the benchmark function. Internal only,
-        you should not need to set this yourself.
-    setUp: Callable[..., None]
-        A setup hook run before the benchmark. Must take all members of `params` as inputs.
-    tearDown: Callable[..., None]
-        A teardown hook run after the benchmark. Must take all members of `params` as inputs.
-    tags: tuple[str, ...]
-        Additional tags to attach for bookkeeping and selective filtering during runs.
     """
 
     fn: Callable[..., Any]
+    """The function defining the benchmark."""
     name: str = ""
+    """A name to display for the given benchmark. If not given, a name will be constructed from the function name and given parameters."""
     params: dict[str, Any] = field(default_factory=dict)
+    """A partial parametrization to apply to the benchmark function. Internal only, you should not need to set this yourself."""
     setUp: Callable[[State, Mapping[str, Any]], None] = field(repr=False, default=NoOp)
+    """A setup hook run before the benchmark. Must take all members of ``params`` as inputs."""
     tearDown: Callable[[State, Mapping[str, Any]], None] = field(repr=False, default=NoOp)
+    """A teardown hook run after the benchmark. Must take all members of ``params`` as inputs."""
     tags: tuple[str, ...] = field(repr=False, default=())
+    """Additional tags to attach for bookkeeping and selective filtering during runs."""
     interface: Interface = field(init=False, repr=False)
+    """Benchmark interface, constructed from the given function. Implementation detail."""
 
     def __post_init__(self):
         if not self.name:
@@ -138,9 +144,11 @@ class Benchmark:
 @dataclass(init=False, frozen=True)
 class Parameters:
     """
-    A dataclass designed to hold benchmark parameters. This class is not functional
-    on its own, and needs to be subclassed according to your benchmarking workloads.
+    A dataclass designed to hold benchmark parameters.
 
-    The main advantage over passing parameters as a dictionary is, of course,
-    static analysis and type safety for your benchmarking code.
+    This class is not functional on its own, and needs to be subclassed
+    according to your benchmarking workloads.
+
+    The main advantage over passing parameters as a dictionary are static analysis
+    and type safety for your benchmarking code.
     """

--- a/src/nnbench/types/interface.py
+++ b/src/nnbench/types/interface.py
@@ -1,4 +1,4 @@
-"""Type interface for the function interface"""
+"""A dataclass representing a Python function interface."""
 
 import inspect
 import sys

--- a/src/nnbench/types/interface.py
+++ b/src/nnbench/types/interface.py
@@ -18,34 +18,33 @@ Variable = tuple[str, type, Any]
 @dataclass(frozen=True)
 class Interface:
     """
-    Data model representing a function's interface. An instance of this class
-    is created using the `from_callable` class method.
+    Data model representing a function's interface.
 
-    Parameters:
-    ----------
-    names : tuple[str, ...]
-        Names of the function parameters.
-    types : tuple[type, ...]
-        Types of the function parameters.
-    defaults : tuple
-        A tuple of the function parameters' default values.
-    variables : tuple[Variable, ...]
-        A tuple of tuples, where each inner tuple contains the parameter name and type.
-    returntype: type
-        The function's return type annotation, or NoneType if left untyped.
+    An instance of this class is created using the ``Interface.from_callable()``
+    class method.
     """
 
     funcname: str
+    """Name of the function."""
     names: tuple[str, ...]
+    """Names of the function parameters."""
     types: tuple[type, ...]
+    """Type hints of the function parameters."""
     defaults: tuple
+    """The function parameters' default values, or inspect.Parameter.empty if a parameter has no default."""
     variables: tuple[Variable, ...]
+    """A tuple of tuples, where each inner tuple contains the parameter name, type, and default value."""
     returntype: type
+    """The function's return type annotation, or NoneType if left untyped."""
 
     @classmethod
     def from_callable(cls, fn: Callable, defaults: dict[str, Any]) -> Self:
         """
         Creates an interface instance from the given callable.
+
+        Wraps the information given by ``inspect.signature()``, with the option to
+        supply a ``defaults`` map and overwrite any default set in the function's
+        signature.
         """
         # Set `follow_wrapped=False` to get the partially filled interfaces.
         # Otherwise we get missing value errors for parameters supplied in benchmark decorators.

--- a/src/nnbench/types/memo.py
+++ b/src/nnbench/types/memo.py
@@ -1,3 +1,5 @@
+"""Tools for automatic, type safe efficient memoization of values in benchmark runs."""
+
 import collections
 import functools
 import inspect


### PR DESCRIPTION
Also fix a bug in `nnbench.util.flatten()`, which did not use the correct key on a dictionary update.

Working towards #177.