### PR TITLE
Fix dead nnbench logo link, remove stale TODO from quickstart

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -2,3 +2,11 @@
 
 The nnbench user guide provides documentation for users of the library looking to solve specific tasks.
 See the [Quickstart guide](../quickstart.md) for an introductory tutorial.
+
+The following guides are available, covering the core concepts of nnbench:
+
+* [Defining benchmarks and benchmark families with decorators](benchmarks.md)
+* [Adding context, customizing benchmarks, and supplying parameters](customization.md)
+* [Organizing benchmark code efficiently](organization.md)
+* [Collecting and running benchmarks by hand](runners.md)
+* [Using memoization for memory efficiency](memoization.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ You will define a benchmark, initialize a runner and reporter, and execute the b
 ## A short scikit-learn model benchmark 
 
 In the following simple example, we put the training and benchmarking logic in the same file. For more complex workloads, we recommend structuring your code into multiple files to improve project organization, similarly to unit tests.
-See the user guides (TODO: Add guides) at the bottom of this page for inspiration.
+Check the [user guide on structuring your benchmarks](guides/organization.md) for inspiration.
 
 ```python
 from sklearn.datasets import load_iris

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: nnbench
 site_dir: public/docs
-site_url: https://nnbench.github.io
+site_url: https://aai-institute.github.io/nnbench
 repo_url: https://github.com/aai-institute/nnbench
 edit_uri: edit/main/docs/
 
@@ -130,7 +130,7 @@ theme:
 
 extra:
   copyright_link: https://appliedai-institute.de
-  homepage: https://nnbench.github.io
+  homepage: https://aai-institute.github.io/nnbench
   generator: false
   pre_release: !ENV [DOCS_PRERELEASE, false]
   version:


### PR DESCRIPTION
The guide has been written in the meantime.