### PR TITLE
Add zizmor pre-commit hook

### DIFF
--- a/.github/actions/mike-docs/action.yaml
+++ b/.github/actions/mike-docs/action.yaml
@@ -26,10 +26,13 @@ runs:
     shell: bash
   - env:
       DOCS_PRERELEASE: ${{ inputs.pre_release }}
+      INPUTS_PUSH: ${{ inputs.push }}
+      INPUTS_VERSION: ${{ inputs.version }}
+      INPUTS_ALIAS: ${{ inputs.alias }}
     run: |
       MIKE_OPTIONS=( "--update-aliases" )
-      if [ "true" = "${{ inputs.push }}" ]; then
+      if [ "true" = "${INPUTS_PUSH}" ]; then
         MIKE_OPTIONS+=( "--push" )
       fi
-      uv run mike deploy ${{ inputs.version }} ${{ inputs.alias }} "${MIKE_OPTIONS[@]}"
+      uv run mike deploy "${INPUTS_VERSION}" ${INPUTS_ALIAS} "${MIKE_OPTIONS[@]}"
     shell: bash

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -30,6 +32,8 @@ jobs:
         python-version: [ "3.10", 3.11, 3.12, 3.13 ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -43,6 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,19 +10,24 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
      - id: mypy
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --explicit-package-bases]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.8.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.10
+    rev: 0.5.15
     hooks:
       - id: uv-lock
         name: Lock project dependencies
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.0.1
+    hooks:
+      - id: zizmor
+        args: [--min-severity=medium]


### PR DESCRIPTION
Mirrors the same change in https://github.com/aai-institute/lakefs-spec/pull/311.

Findings include the frequently missing `persist-credentials`, and a template injection hint for our mike action, which appears three times (?).