### PR TITLE
Persist credentials for mike push jobs

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true  # needed for mike to publish.
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
Otherwise, no commit can be pushed by mike.

The optimal solution would be to persist only in the event of "push on main" (hence why I merged the initial zizmor PR, the CI was green because no push occurred), but that's outside the scope of zizmor for now, which will flag anything but "true".