### PR TITLE
Add `BenchmarkFamily` iterable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ Discussions = "https://github.com/aai-institute/nnbench/discussions"
 dev = [
     "build>=1.0.0",
     "fsspec",
+    "numpy>=2.2.1",
     "pre-commit>=3.3.3",
     "psutil",
     "pyarrow",

--- a/src/nnbench/core.py
+++ b/src/nnbench/core.py
@@ -159,6 +159,7 @@ def parametrize(
         A parametrized decorator returning the benchmark family.
     """
 
+    # TODO(nicholasjng): Return a BenchmarkFamily object.
     def decorator(fn: Callable) -> list[Benchmark]:
         benchmarks = []
         names = set()
@@ -222,6 +223,7 @@ def product(
         A parametrized decorator returning the benchmark family.
     """
 
+    # TODO(nicholasjng): Return a BenchmarkFamily object.
     def decorator(fn: Callable) -> list[Benchmark]:
         benchmarks = []
         names = set()

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -9,7 +9,7 @@ import platform
 import sys
 import time
 import uuid
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import Callable, Generator, Iterable, Sequence
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
@@ -148,7 +148,7 @@ def collect(path_or_module: str | os.PathLike[str], tags: tuple[str, ...] = ()) 
 
 
 def run(
-    benchmarks: Benchmark | Sequence[Benchmark],  # TODO: Support benchmark iterators
+    benchmarks: Benchmark | Iterable[Benchmark],
     name: str | None = None,
     params: dict[str, Any] | Parameters | None = None,
     context: Sequence[ContextProvider] = (),
@@ -203,8 +203,8 @@ def run(
     if not benchmarks:
         return BenchmarkRecord(run=_run, context=ctx, benchmarks=[])
 
-    for bm in benchmarks:
-        family_sizes[bm.interface.funcname] += 1
+    # for bm in benchmarks:
+    #     family_sizes[bm.interface.funcname] += 1
 
     if isinstance(params, Parameters):
         dparams = asdict(params)

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -3,7 +3,7 @@
 import copy
 import inspect
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import asdict, dataclass, field
 from types import MappingProxyType
 from typing import Any, TypeVar
@@ -202,3 +202,14 @@ class Benchmark:
         if not self.name:
             super().__setattr__("name", self.fn.__name__)
         super().__setattr__("interface", Interface.from_callable(self.fn, self.params))
+
+
+class BenchmarkFamily(Iterable[Benchmark]):
+    def __init__(self, fn: Callable[..., Any], params: Iterable[dict[str, Any]]):
+        self.fn = fn
+        self.params = params
+
+    def __iter__(self):
+        # TODO(nicholasjng): Yield benchmark members as currently done in
+        #  `core.{parametrize,product}`.
+        pass

--- a/tests/integration/test_benchmark_family_memory_consumption.py
+++ b/tests/integration/test_benchmark_family_memory_consumption.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+import nnbench
+
+N = 1024
+NUM_REPLICAS = 3
+NP_MATSIZE_BYTES = N**2 * np.float64().itemsize
+# for a matmul, we alloc LHS, RHS, and RESULT.
+# math.ceil gives us a cushion of up to 1MiB, which is for other system allocs.
+EXPECTED_MEM_USAGE_MB = 3 * NP_MATSIZE_BYTES / 1048576 + 0.5
+
+
+@pytest.mark.limit_memory(f"{EXPECTED_MEM_USAGE_MB}MB")
+def test_parametrize_memory_consumption():
+    """
+    Checks that a benchmark family works with GC in the parametrization case,
+    and produces the theoretically optimal memory usage pattern for a matmul.
+
+    Note: We do not have a similar "best case" memory guarantee for @nnbench.product,
+    because the evaluation of the cartesian product via `itertools.product()` forces
+    the eager exhaustion of all iterables (generators can be used only once).
+    """
+
+    @nnbench.parametrize({"b": np.zeros((N, N), dtype=np.int64)} for _ in range(NUM_REPLICAS))
+    def matmul(a: np.ndarray, b: np.ndarray) -> np.float64:
+        return np.dot(a, b).sum()
+
+    a = np.zeros((N, N), dtype=np.int64)
+    nnbench.run(matmul, params={"a": a})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,3 @@
-import pytest
-
 import nnbench
 import nnbench.types
 from nnbench import benchmark, parametrize, product
@@ -29,19 +27,12 @@ def test_parametrize():
     def parametrized_benchmark(param: int) -> int:
         return param
 
-    assert len(parametrized_benchmark) == 2
-    assert has_expected_args(parametrized_benchmark[0].fn, {"param": 1})
-    assert parametrized_benchmark[0].fn(**parametrized_benchmark[0].params) == 1
-    assert has_expected_args(parametrized_benchmark[1].fn, {"param": 2})
-    assert parametrized_benchmark[1].fn(**parametrized_benchmark[1].params) == 2
-
-
-def test_parametrize_with_duplicate_parameters():
-    with pytest.warns(UserWarning, match="duplicate"):
-
-        @parametrize([{"param": 1}, {"param": 1}])
-        def parametrized_benchmark(param: int) -> int:
-            return param
+    all_benchmarks = list(parametrized_benchmark)
+    assert len(all_benchmarks) == 2
+    assert has_expected_args(all_benchmarks[0].fn, {"param": 1})
+    assert all_benchmarks[0].fn(**all_benchmarks[0].params) == 1
+    assert has_expected_args(all_benchmarks[1].fn, {"param": 2})
+    assert all_benchmarks[1].fn(**all_benchmarks[1].params) == 2
 
 
 def test_product():
@@ -49,20 +40,13 @@ def test_product():
     def product_benchmark(iter1: int, iter2: str) -> tuple[int, str]:
         return iter1, iter2
 
-    assert len(product_benchmark) == 4
-    assert has_expected_args(product_benchmark[0].fn, {"iter1": 1, "iter2": "a"})
-    assert product_benchmark[0].fn(**product_benchmark[0].params) == (1, "a")
-    assert has_expected_args(product_benchmark[1].fn, {"iter1": 1, "iter2": "b"})
-    assert product_benchmark[1].fn(**product_benchmark[1].params) == (1, "b")
-    assert has_expected_args(product_benchmark[2].fn, {"iter1": 2, "iter2": "a"})
-    assert product_benchmark[2].fn(**product_benchmark[2].params) == (2, "a")
-    assert has_expected_args(product_benchmark[3].fn, {"iter1": 2, "iter2": "b"})
-    assert product_benchmark[3].fn(**product_benchmark[3].params) == (2, "b")
-
-
-def test_product_with_duplicate_parameters():
-    with pytest.warns(UserWarning, match="duplicate"):
-
-        @product(iter=[1, 1])
-        def product_benchmark(iter: int) -> int:
-            return iter
+    all_benchmarks = list(product_benchmark)
+    assert len(all_benchmarks) == 4
+    assert has_expected_args(all_benchmarks[0].fn, {"iter1": 1, "iter2": "a"})
+    assert all_benchmarks[0].fn(**all_benchmarks[0].params) == (1, "a")
+    assert has_expected_args(all_benchmarks[1].fn, {"iter1": 1, "iter2": "b"})
+    assert all_benchmarks[1].fn(**all_benchmarks[1].params) == (1, "b")
+    assert has_expected_args(all_benchmarks[2].fn, {"iter1": 2, "iter2": "a"})
+    assert all_benchmarks[2].fn(**all_benchmarks[2].params) == (2, "a")
+    assert has_expected_args(all_benchmarks[3].fn, {"iter1": 2, "iter2": "b"})
+    assert all_benchmarks[3].fn(**all_benchmarks[3].params) == (2, "b")


### PR DESCRIPTION
Designed to consume the arguments of `parametrize`/`product`, and yield benchmarks lazily.

Params needs to support lazy iterables as well, to not fall into the eager materialization + memory blowup trap.

--------------------------

Testing should contain these scenarios at minimum:

1) Confirm that `BenchmarkFamily`s are being picked up by `nnbench.collect()`, similarly to existing collect checks.
2) Add a test that would fail with an eager iterable (e.g. `list[Benchmark` like it is now), asserting memory consumption stays low e.g. with memray.

Proposal for 2):

Add a benchmark `matmul(a: np.ndarray, b: np.ndarray)` with two arrays $a, b \in \mathbb{R}^{N \times N}$, parametrize over one of them (five `np.random.randn`s should suffice), assert that memory consumption stays near `3 * N^2 * sizeof(np.float)` (a, b, and the intermediary for the result).