### PR TITLE
docs: Remove stale `BenchmarkRunner` references, update hooks

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,5 +1,7 @@
 name: Lint and test nnbench
 
+permissions: {}
+
 on:
   push:
     branches:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,7 @@
 name: Build and publish Python wheel and sdist
 
+permissions: {}
+
 on:
   workflow_dispatch:
   release:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,18 +16,18 @@ repos:
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --explicit-package-bases]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.20
+    rev: 0.5.21
     hooks:
       - id: uv-lock
         name: Lock project dependencies
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.0.1
+    rev: v1.2.2
     hooks:
       - id: zizmor
         args: [--min-severity=medium]

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -70,11 +70,9 @@ Lastly, we set up a benchmark runner in the `main.py`. There, we supply the para
 # main.py
 import nnbench
 
-
-r = nnbench.BenchmarkRunner()
-reporter = nnbench.BenchmarkReporter()
-
-result = r.run("benchmarks.py", params={"n_estimators": 100, "max_depth": 5, "random_state": 42})
+reporter = nnbench.ConsoleReporter()
+benchmarks = nnbench.collect("benchmarks.py")
+result = nnbench.run(benchmarks, params={"n_estimators": 100, "max_depth": 5, "random_state": 42})
 reporter.display(result)
 ```
 
@@ -115,17 +113,15 @@ def benchmark_accuracy(n_estimators: int, max_depth: int, random_state: int) -> 
 ```
 
 Notice that the parametrization is still incomplete, as we did not supply a `random_state` argument.
-The unfilled arguments are given in `BenchmarkRunner.run()` via a dictionary passed as the `params` keyword argument.
+The unfilled arguments are given in `nnbench.run()` via a dictionary passed as the `params` keyword argument.
 
 ```python
 # main.py
 import nnbench
 
-
-r = nnbench.BenchmarkRunner()
-reporter = nnbench.BenchmarkReporter()
-
-result = r.run("benchmarks.py", params={"random_state": 42})
+benchmarks = nnbench.collect("benchmarks.py")
+reporter = nnbench.ConsoleReporter()
+result = nnbench.run(benchmarks, params={"random_state": 42})
 reporter.display(result)
 ```
 

--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -73,7 +73,7 @@ def platinfo() -> dict[str, str]:
     }
 ```
 
-To supply context to your benchmarks, you can give a sequence of context providers to `BenchmarkRunner.run()`:
+To supply context to your benchmarks, you can give a sequence of context providers to `nnbench.run()`:
 
 ```python
 import nnbench

--- a/docs/guides/organization.md
+++ b/docs/guides/organization.md
@@ -40,10 +40,11 @@ This is helpful when running multiple benchmark workloads separately, as you can
 ```python
 import nnbench
 
-runner = nnbench.BenchmarkRunner()
-data_metrics = runner.run("benchmarks/data_quality.py", params=...)
+data_quality_benchmarks = nnbench.collect("benchmarks/data_quality.py")
+data_metrics = nnbench.run(data_quality_benchmarks, params=...)
 # same for model metrics, where instead you pass benchmarks/model_perf.py.
-model_metrics = runner.run("benchmarks/model_perf.py", params=...)
+model_perf_benchmarks = nnbench.collect("benchmarks/model_perf.py")
+model_metrics = nnbench.run(model_perf_benchmarks, params=...)
 ```
 
 ## Tip 3: Attach tags to benchmarks for selective filtering
@@ -70,7 +71,7 @@ def bar(data) -> int:
     ...
 ```
 
-Now, to only run data quality benchmarks marked "foo", pass the corresponding tag to `BenchmarkRunner.run()`:
+Now, to only run data quality benchmarks marked "foo", pass the corresponding tag to `nnbench.run()`:
 
 ```python
 import nnbench

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,13 +44,11 @@ Then, using the `BenchmarkReporter` we report the resulting accuracy metric by p
 ```python
 import nnbench
 
-
-r = nnbench.BenchmarkRunner()
-reporter = nnbench.BenchmarkReporter()
-
+benchmarks = nnbench.collect(__main__)
+reporter = nnbench.ConsoleReporter()
 # To collect in the current file, pass "__main__" as module name.
-result = r.run("__main__", params={"model": model, "X_test": X_test, "y_test": y_test})
-reporter.display(result)
+record = nnbench.run(benchmarks, params={"model": model, "X_test": X_test, "y_test": y_test})
+reporter.display(record)
 ```
 
 The resulting output might look like this:


### PR DESCRIPTION
These were leftover from the (semi-)recent change to functional APIs.

-----------

This accommodates new audits of zizmor targeted at excessive / unset workflow permissions.