### PR TITLE
core: Discover benchmark families as well

### DIFF
--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -3,6 +3,6 @@
 from .core import benchmark, parametrize, product
 from .reporter import BenchmarkReporter, ConsoleReporter, FileReporter
 from .runner import collect, run
-from .types import Benchmark, BenchmarkRecord, Parameters
+from .types import Benchmark, BenchmarkFamily, BenchmarkRecord, Parameters
 
 __version__ = "0.4.0"


### PR DESCRIPTION
Requires some tweaking of designated benchmark types in `nnbench.collect()` and `nnbench.run()`. Now, we pick up every module member that is either a `Benchmark` or `BenchmarkFamily`. Finally, in `nnbench.run()`, we create a composite iterator over our findings (currently, most often a list, but single benchmarks / families are also supported), which allows to keep the main loop intact no matter what the user chooses to pass.

--------------

Next is the removal of `family_size` from the `State`, since we cannot be sure about the size of a family anymore when parametrizing over generators. 