### PR TITLE
docs: Allow writes for mike action

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -45,6 +45,8 @@ jobs:
   docs:
     name: Publish latest documentation for nnbench
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This allows docs deployments on `main` pushes.