### PR TITLE
feat(cli): Add `-j` option for running benchmarks in parallel

### DIFF
--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -100,6 +100,12 @@ def construct_parser(config: NNBenchConfig) -> argparse.ArgumentParser:
         default="benchmarks",
     )
     run_parser.add_argument(
+        "-j",
+        type=int,
+        default=None,
+        help="Number of processes to use for running benchmarks in parallel, default: no parallelism"
+    )
+    run_parser.add_argument(
         "--context",
         action="append",
         metavar="<key=value>",
@@ -205,6 +211,7 @@ def main() -> int:
                 else:
                     context[k] = v
 
+            # TODO: Add multiprocessing/joblib branch for parallel execution.
             benchmarks = collect(args.benchmarks, tags=tuple(args.tags))
             record = run(
                 benchmarks,

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -3,12 +3,20 @@
 import argparse
 import importlib
 import logging
+import multiprocessing
 import sys
+import time
+from collections.abc import Iterable
+from functools import partial
+from os import PathLike
+from pathlib import Path
 from typing import Any
 
 from nnbench import ConsoleReporter, __version__, collect, run
 from nnbench.config import NNBenchConfig, parse_nnbench_config
+from nnbench.context import Context, ContextProvider
 from nnbench.reporter import FileReporter
+from nnbench.types import BenchmarkRecord
 
 _VERSION = f"%(prog)s version {__version__}"
 logger = logging.getLogger("nnbench")
@@ -72,6 +80,21 @@ def _log_level(log_level: str) -> str:
 _log_level.__name__ = "log level"
 
 
+def collect_and_run(
+    path: str | PathLike[str],
+    name: str | None = None,
+    tags: tuple[str, ...] = (),
+    context: Context | Iterable[ContextProvider] = (),
+) -> BenchmarkRecord:
+    benchmarks = collect(path, tags=tags)
+    record = run(
+        benchmarks,
+        name=name,
+        context=context,
+    )
+    return record
+
+
 def construct_parser(config: NNBenchConfig) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser("nnbench", formatter_class=CustomFormatter)
     parser.add_argument("--version", action="version", version=_VERSION)
@@ -102,8 +125,9 @@ def construct_parser(config: NNBenchConfig) -> argparse.ArgumentParser:
     run_parser.add_argument(
         "-j",
         type=int,
-        default=None,
-        help="Number of processes to use for running benchmarks in parallel, default: no parallelism"
+        default=-1,
+        dest="jobs",
+        help="Number of processes to use for running benchmarks in parallel, default: -1 (no parallelism)",
     )
     run_parser.add_argument(
         "--context",
@@ -170,12 +194,12 @@ def construct_parser(config: NNBenchConfig) -> argparse.ArgumentParser:
     return parser
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     """The main ``nnbench`` CLI entry point."""
     config = parse_nnbench_config()
     parser = construct_parser(config)
     try:
-        args = parser.parse_args()
+        args = parser.parse_args(argv)
         if args.command is None:
             parser.print_help()
             return 1
@@ -211,12 +235,38 @@ def main() -> int:
                 else:
                     context[k] = v
 
-            # TODO: Add multiprocessing/joblib branch for parallel execution.
-            benchmarks = collect(args.benchmarks, tags=tuple(args.tags))
-            record = run(
-                benchmarks,
-                context=[lambda: context],
-            )
+            n_jobs: int = args.jobs
+            if n_jobs < 2:
+                record = collect_and_run(
+                    args.benchmarks,
+                    tags=tuple(args.tags),
+                    context=context,
+                )
+            else:
+
+                def flatten(lists):
+                    for _l in lists:
+                        yield from _l
+
+                compute_fn = partial(
+                    collect_and_run,
+                    name=f"nnbench-{time.time_ns()}",  # TODO: Use a better name here
+                    tags=tuple(args.tags),
+                    context=context,
+                )
+                with multiprocessing.Pool(n_jobs) as p:
+                    bm_path = Path(args.benchmarks)
+                    # unroll paths in case a directory is passed.
+                    if bm_path.is_dir():
+                        benchmarks = [p for p in bm_path.iterdir() if p.suffix == ".py"]
+                    else:
+                        benchmarks = [bm_path]
+                    res = p.map(compute_fn, benchmarks)
+                    record = BenchmarkRecord(
+                        run=res[0].run,
+                        context=res[0].context,
+                        benchmarks=list(flatten(r.benchmarks for r in res)),
+                    )
 
             outfile = args.outfile
             if outfile == sys.stdout:
@@ -239,4 +289,4 @@ def main() -> int:
         return 0
     except Exception as e:
         sys.stderr.write(f"error: {e}")
-        sys.exit(1)
+        return 1

--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -5,7 +5,8 @@ import sys
 from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
-ContextProvider = Callable[[], dict[str, Any]]
+Context = dict[str, Any]
+ContextProvider = Callable[[], Context]
 """A function providing a dictionary of context values."""
 
 

--- a/tests/cli/benchmarks/a.py
+++ b/tests/cli/benchmarks/a.py
@@ -1,0 +1,9 @@
+import time
+
+import nnbench
+
+
+@nnbench.benchmark
+def add(a: int, b: int) -> int:
+    time.sleep(10)
+    return a + b

--- a/tests/cli/benchmarks/b.py
+++ b/tests/cli/benchmarks/b.py
@@ -1,0 +1,9 @@
+import time
+
+import nnbench
+
+
+@nnbench.benchmark
+def mul(a: int, b: int) -> int:
+    time.sleep(10)
+    return a * b

--- a/tests/cli/conf.py
+++ b/tests/cli/conf.py
@@ -1,0 +1,6 @@
+def a() -> int:
+    return 1
+
+
+def b() -> int:
+    return 2

--- a/tests/cli/test_parallel_exec.py
+++ b/tests/cli/test_parallel_exec.py
@@ -1,0 +1,24 @@
+import time
+from pathlib import Path
+
+from nnbench.cli import main
+
+DELAY_SECONDS = 10
+
+
+def test_parallel_execution_for_slow_benchmarks():
+    """
+    Verifies that benchmarks with long execution time finish faster
+    when using process parallelism.
+    All discovered benchmarks contain a time.sleep(DELAY_SECONDS) call,
+    and are just a simple add/mul of two integers, so we expect the
+    execution time to be slightly above DELAY_SECONDS.
+    """
+    n_jobs = 2
+    bm_path = Path(__file__).parent / "benchmarks"
+    start = time.time()
+    args = ["run", f"{bm_path}", "-j2"]
+    rc = main(args)
+    end = time.time() - start
+    assert rc == 0, f"running nnbench {' '.join(args)} failed with exit code {rc}"
+    assert end - start < n_jobs * DELAY_SECONDS


### PR DESCRIPTION
Usage: `nnbench run <benchmarks> -jN`.

Similar to make, but using process parallelism. The default is to not use multiple processes. What's left to decide is whether to require joblib as a hard dependency for parallelism, to simplify the control flow in the CLI.