### PR TITLE
fix: Use walk() to traverse more than one directory in benchmark collection

### DIFF
--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -17,6 +17,7 @@ from nnbench.config import NNBenchConfig, parse_nnbench_config
 from nnbench.context import Context, ContextProvider
 from nnbench.reporter import FileReporter
 from nnbench.types import BenchmarkRecord
+from nnbench.util import all_python_files
 
 _VERSION = f"%(prog)s version {__version__}"
 logger = logging.getLogger("nnbench")
@@ -258,7 +259,7 @@ def main(argv: list[str] | None = None) -> int:
                     bm_path = Path(args.benchmarks)
                     # unroll paths in case a directory is passed.
                     if bm_path.is_dir():
-                        benchmarks = [p for p in bm_path.iterdir() if p.suffix == ".py"]
+                        benchmarks = all_python_files(bm_path)
                     else:
                         benchmarks = [bm_path]
                     res = p.map(compute_fn, benchmarks)

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -18,7 +18,7 @@ from typing import Any
 from nnbench.context import Context, ContextProvider
 from nnbench.fixtures import FixtureManager
 from nnbench.types import Benchmark, BenchmarkFamily, BenchmarkRecord, Parameters, State
-from nnbench.util import exists_module, import_file_as_module
+from nnbench.util import all_python_files, exists_module, import_file_as_module
 
 Benchmarkable = Benchmark | BenchmarkFamily
 
@@ -118,7 +118,7 @@ def collect(
     benchmarks: list[Benchmark] = []
     ppath = Path(path_or_module)
     if ppath.is_dir():
-        pythonpaths = (p for p in ppath.iterdir() if p.suffix == ".py")
+        pythonpaths = all_python_files(ppath)
         for py in pythonpaths:
             logger.debug(f"Collecting benchmarks from submodule {py.name!r}.")
             benchmarks.extend(collect(py, tags))


### PR DESCRIPTION
Previously, when inputting a directory for benchmarking, only benchmarks at that directory level were collected because of the use of `Path.iterdir()`.

However, if we want to support arbitrary depth in a benchmark directory layout, we need to use depth traversal, which is facilitated either by os.walk() or, for 3.12 and newer, Path.walk().

Changes both callsites (CLI+multiprocessing and `nnbench.collect()`) to the new `all_python_files()` API.