### PR TITLE
Add MLFlowIO to enable MLflow logging of benchmark results

### DIFF
--- a/src/nnbench/reporter/__init__.py
+++ b/src/nnbench/reporter/__init__.py
@@ -3,5 +3,39 @@ An interface for displaying, writing, or streaming benchmark results to
 files, databases, or web services.
 """
 
+import os
+from enum import Enum
+from typing import TextIO
+
 from .console import ConsoleReporter
 from .file import FileReporter
+
+
+class IOType(str, Enum):
+    STDOUT = "stdout"
+    FILE = "file"
+    DATABASE = "database"
+    SERVICE = "service"  # TODO: Pick a better name
+    UNKNOWN = "unknown"
+
+
+def get_io_type(uri: str | os.PathLike[str] | TextIO) -> IOType:
+    import sys
+
+    if uri is sys.stdout:
+        return IOType.STDOUT
+
+    from nnbench.util import get_protocol
+
+    proto = get_protocol(uri)
+    if proto in ["az", "file", "gcs", "gs", "lakefs", "s3"]:
+        return IOType.FILE
+    elif proto in ["sqlite"]:  # TODO: Not yet supported
+        return IOType.DATABASE
+    elif proto in ["mlflow"]:
+        return IOType.SERVICE
+    else:
+        return IOType.UNKNOWN
+
+
+del Enum, os, TextIO

--- a/src/nnbench/reporter/file.py
+++ b/src/nnbench/reporter/file.py
@@ -184,11 +184,12 @@ _file_io_mapping: dict[str, type[BenchmarkFileIO]] = {
 }
 
 
-def get_file_io_class(name: str) -> BenchmarkFileIO:
+def get_file_io_class(file: str | os.PathLike[str]) -> BenchmarkFileIO:
+    ext = get_extension(file)
     try:
-        return _file_io_mapping[name]()
+        return _file_io_mapping[ext]()
     except KeyError:
-        raise ValueError(f"unsupported benchmark file format {name!r}") from None
+        raise ValueError(f"unsupported benchmark file format {ext!r}") from None
 
 
 def register_file_io_class(name: str, klass: type[BenchmarkFileIO], clobber: bool = False) -> None:

--- a/src/nnbench/reporter/service.py
+++ b/src/nnbench/reporter/service.py
@@ -1,0 +1,96 @@
+import os
+from contextlib import ExitStack
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+from nnbench.types import BenchmarkRecord
+from nnbench.util import get_protocol
+
+if TYPE_CHECKING:
+    from mlflow import ActiveRun as ActiveRun
+
+
+class BenchmarkServiceIO(Protocol):
+    def read(self, uri: str | os.PathLike[str], options: dict[str, Any]) -> BenchmarkRecord: ...
+
+    def write(
+        self, record: BenchmarkRecord, uri: str | os.PathLike[str], options: dict[str, Any]
+    ) -> None: ...
+
+
+class MLFlowIO(BenchmarkServiceIO):
+    def __init__(self):
+        import mlflow
+
+        self.mlflow = mlflow
+        self.stack = ExitStack()
+
+    @staticmethod
+    def strip_protocol(uri: str | os.PathLike[str]) -> str:
+        s = str(uri)
+        if s.startswith("mlflow://"):
+            return s[9:]
+        return s
+
+    def get_or_create_run(self, run_name: str, nested: bool = False) -> "ActiveRun":
+        existing_runs = self.mlflow.search_runs(
+            filter_string=f"attributes.`run_name`={run_name!r}", output_format="list"
+        )
+        if existing_runs:
+            run_id = existing_runs[0].info.run_id
+            return self.mlflow.start_run(run_id=run_id, nested=nested)
+        else:
+            return self.mlflow.start_run(run_name=run_name, nested=nested)
+
+    def read(self, uri: str | os.PathLike[str], options: dict[str, Any]) -> BenchmarkRecord:
+        raise NotImplementedError
+
+    def write(
+        self, record: BenchmarkRecord, uri: str | os.PathLike[str], options: dict[str, Any]
+    ) -> None:
+        uri = self.strip_protocol(uri)
+        try:
+            experiment, run_name, *subruns = Path(uri).parts
+        except ValueError:
+            raise ValueError(f"expected URI of form <experiment>/<run>[/<subrun>]..., got {uri!r}")
+
+        # setting experiment removes the need for passing the `experiment_id` kwarg
+        # in the subsequent API calls.
+        self.mlflow.set_experiment(experiment_name=experiment)
+
+        run = self.stack.enter_context(self.get_or_create_run(run_name=run_name))
+        for s in subruns:
+            # reassignment ensures that we log into the max-depth subrun specified.
+            run = self.stack.enter_context(self.get_or_create_run(run_name=s, nested=True))
+
+        self.mlflow.log_dict(record.context, "context.json", run_id=run.info.run_id)
+        for bm in record.benchmarks:
+            name, value = bm["name"], bm["value"]
+            timestamp = int(datetime.fromisoformat(bm["date"]).timestamp())
+            self.mlflow.log_metric(name, value, timestamp=timestamp, run_id=run.info.run_id)
+
+
+# TODO: Investigate if this can be merged with the file io mapping to a top-level struct
+#  (e.g. with a value union type BenchmarkFileIO | BenchmarkServiceIO | ...)
+_service_io_mapping: dict[str, type[BenchmarkServiceIO]] = {
+    "mlflow": MLFlowIO,
+}
+
+
+def get_service_io_class(uri: str) -> BenchmarkServiceIO:
+    proto = get_protocol(uri)
+    try:
+        return _service_io_mapping[proto]()
+    except KeyError:
+        raise ValueError(f"unsupported benchmark IO: {proto!r}") from None
+
+
+def register_file_io_class(
+    name: str, klass: type[BenchmarkServiceIO], clobber: bool = False
+) -> None:
+    if name in _service_io_mapping and not clobber:
+        raise RuntimeError(
+            f"IO {name!r} is already registered (to force registration, rerun with clobber=True)"
+        )
+    _service_io_mapping[name] = klass

--- a/src/nnbench/util.py
+++ b/src/nnbench/util.py
@@ -4,12 +4,13 @@ import importlib
 import importlib.util
 import itertools
 import os
+import re
 import sys
 from collections.abc import Generator
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import IO, Any
 
 
 def flatten(d: dict[str, Any], sep: str = ".", prefix: str = "") -> dict:
@@ -182,3 +183,22 @@ def all_python_files(_dir: str | os.PathLike[str]) -> Generator[Path, None, None
             fp = proot / file
             if fp.suffix == ".py":
                 yield fp
+
+
+def get_protocol(url: str | os.PathLike[str]) -> str:
+    url = str(url)
+    parts = re.split(r"(::|://)", url, maxsplit=1)
+    if len(parts) > 1:
+        return parts[0]
+    return "file"
+
+
+def get_extension(f: str | os.PathLike[str] | IO) -> str:
+    """
+    Given a path or file-like object, returns file extension
+    (can be the empty string, if the file has no extension).
+    """
+    if isinstance(f, str | os.PathLike):
+        return Path(f).suffix
+    else:
+        return Path(f.name).suffix

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from nnbench.reporter.file import FileReporter
+from nnbench.reporter.file import get_file_io_class
 from nnbench.types import BenchmarkRecord
 
 
@@ -12,7 +12,6 @@ from nnbench.types import BenchmarkRecord
 )
 def test_fileio_writes_no_compression_inline(tmp_path: Path, ext: str) -> None:
     """Tests data integrity for file IO roundtrips with both context modes."""
-    f = FileReporter()
 
     rec = BenchmarkRecord(
         run="my-run",
@@ -20,8 +19,9 @@ def test_fileio_writes_no_compression_inline(tmp_path: Path, ext: str) -> None:
         benchmarks=[{"name": "foo", "value": 1}, {"name": "bar", "value": 2}],
     )
     file = tmp_path / f"record.{ext}"
-    f.write(rec, file)
-    rec2 = f.read(file)
+    f = get_file_io_class(file)
+    f.write(rec, file, {})
+    rec2 = f.read(file, {})
     # Python stdlib csv coerces everything to string.
     if ext == "csv":
         for bm1, bm2 in zip(rec.benchmarks, rec2.benchmarks):


### PR DESCRIPTION
Introduces a `BenchmarkServiceIO` protocol, establishing an interface for streaming JSON results to web services like MLflow, Grafana, WandB, ...

Also introduces multiple dispatch of IO based on the value of `outfile`, i.e. the value of the `-o` switch.

The introduced taxonomy is stdout | file | database | service, and loads a different IO class depending on the detected type of IO requested.

For files, inferring the IO type is a bit harder, since local files are usually given without a leading protocol. For this case, we look at the file extension as well.

Every other IO is detected by the leading protocol of the given URI, so `mlflow://experiment/run/subrun` leads to the MLflow IO being requested.

-------------------------

Usage (create two files, `example.py` and `conf.py`, with the following contents limited by horizontal bars):

```
# -----------------------
# file: example.py
# -----------------------

import nnbench


@nnbench.benchmark
def add(a: int, b: int) -> int:
    return a + b


@nnbench.benchmark(name="My super summation")
def mul(a: int, b: int) -> int:
    return a * b

# -------------------
# file: conf.py
# -------------------

def a() -> int:
    return 200


def b() -> int:
    return 100
```

Then, `nnbench run example.py --context=foo=bar -o mlflow://test/my-run/my-subrun` streams the results into the given nested subrun, under the "test" experiment (which you may have to create beforehand in the UI). You will also have to set `MLFLOW_TRACKING_URI=http://localhost:$PORT` in the shell you're executing from.

Screenshots:

<img width="1440" alt="Screenshot 2025-02-12 at 16 35 48" src="https://github.com/user-attachments/assets/d8fa833c-98a6-415f-977c-afe04111d07b" />

<img width="1438" alt="Screenshot 2025-02-12 at 16 36 11" src="https://github.com/user-attachments/assets/218a4d04-12d3-44f2-bdcd-615a7afa7e7d" />



cc @janwillemkl