### PR TITLE
CLI: Restructure dispatch to be based on URI protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To understand how nnbench works, you can run the following in your Python interp
 ```python
 # example.py
 import nnbench
+from nnbench.reporter import ConsoleReporter
 
 
 @nnbench.benchmark
@@ -43,12 +44,12 @@ def power(a: int, b: int) -> int:
     return a ** b
 
 
-reporter = nnbench.ConsoleReporter()
+reporter = ConsoleReporter()
 # first, collect the above benchmarks directly from the current module...
 benchmarks = nnbench.collect("__main__")
 # ... then run the benchmarks with the parameters `a=2, b=10`...
 record = nnbench.run(benchmarks, params={"a": 2, "b": 10})
-reporter.display(record)  # ...and print the results to the terminal.
+reporter.write(record)  # ...and print the results to the terminal.
 
 # results in a table look like the following:
 # ┏━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -64,7 +64,7 @@ def benchmark_accuracy(n_estimators: int, max_depth: int, random_state: int) -> 
     This training benchmark is designed as a local, simple, and self-contained example to showcase nnbench. 
     In a real world scenario, to follow best practices, you may want to separate the data preparation and model training steps from the benchmarking logic and pass the corresponding artifacts as a parameter to the benchmark. See the user guide for more information.
 
-Lastly, we set up a benchmark runner in the `main.py`. There, we supply the parameters (`n_estimators`, `max_depth`, `random_state`) necessary in the function definition as a dictionary to the `params` keyword argument. 
+Lastly, we set up a benchmark runner in the `main.py`. There, we supply the parameters (`n_estimators`, `max_depth`, `random_state`) necessary in the function definition as a dictionary to the `params` keyword argument.
 
 ```python
 # main.py
@@ -73,7 +73,7 @@ import nnbench
 reporter = nnbench.ConsoleReporter()
 benchmarks = nnbench.collect("benchmarks.py")
 result = nnbench.run(benchmarks, params={"n_estimators": 100, "max_depth": 5, "random_state": 42})
-reporter.display(result)
+reporter.write(result)
 ```
 
 When we execute the `main.py` we get the following output:
@@ -122,7 +122,7 @@ import nnbench
 benchmarks = nnbench.collect("benchmarks.py")
 reporter = nnbench.ConsoleReporter()
 result = nnbench.run(benchmarks, params={"random_state": 42})
-reporter.display(result)
+reporter.write(result)
 ```
 
 Executing the parametrized benchmark, we get an output similar to this:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,12 +43,13 @@ Then, using the `BenchmarkReporter` we report the resulting accuracy metric by p
 
 ```python
 import nnbench
+from nnbench.reporter import ConsoleReporter
 
-benchmarks = nnbench.collect(__main__)
-reporter = nnbench.ConsoleReporter()
+benchmarks = nnbench.collect("__main__")
+reporter = ConsoleReporter()
 # To collect in the current file, pass "__main__" as module name.
 record = nnbench.run(benchmarks, params={"model": model, "X_test": X_test, "y_test": y_test})
-reporter.display(record)
+reporter.write(record)
 ```
 
 The resulting output might look like this:

--- a/examples/huggingface/runner.py
+++ b/examples/huggingface/runner.py
@@ -7,6 +7,7 @@ from transformers import (
 )
 
 import nnbench
+from nnbench.reporter import ConsoleReporter
 
 dataset = load_dataset("conllpp")
 path = dataset.cache_files["validation"][0]["filename"]
@@ -29,9 +30,9 @@ def main() -> None:
     }
 
     benchmarks = nnbench.collect("benchmark.py", tags=("per-class",))
-    reporter = nnbench.ConsoleReporter()
+    reporter = ConsoleReporter()
     result = nnbench.run(benchmarks, params=params)
-    reporter.display(result)
+    reporter.write(result)
 
 
 if __name__ == "__main__":

--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -21,6 +21,7 @@ import optax
 from flax.training.train_state import TrainState
 
 import nnbench
+from nnbench.reporter import FileReporter
 
 HERE = Path(__file__).parent
 
@@ -217,7 +218,7 @@ def mnist_jax():
 
     # the nnbench portion.
     benchmarks = nnbench.collect(HERE)
-    reporter = nnbench.FileReporter()
+    reporter = FileReporter()
     params = MNISTTestParameters(params=state.params, data=data)
     result = nnbench.run(benchmarks, params=params)
     reporter.write(result, "result.json")

--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -1,7 +1,6 @@
 """A framework for organizing and running benchmark workloads on machine learning models."""
 
 from .core import benchmark, parametrize, product
-from .reporter import ConsoleReporter, FileReporter
 from .runner import collect, run
 from .types import Benchmark, BenchmarkFamily, BenchmarkRecord, Parameters
 

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -12,10 +12,10 @@ from os import PathLike
 from pathlib import Path
 from typing import Any
 
-from nnbench import ConsoleReporter, __version__, collect, run
+from nnbench import __version__, collect, run
 from nnbench.config import NNBenchConfig, parse_nnbench_config
 from nnbench.context import Context, ContextProvider
-from nnbench.reporter import FileReporter, IOType, get_io_type
+from nnbench.reporter import FileReporter, get_io_implementation
 from nnbench.types import BenchmarkRecord
 from nnbench.util import all_python_files
 
@@ -270,24 +270,8 @@ def main(argv: list[str] | None = None) -> int:
                     )
 
             outfile = args.outfile
-            io_type = get_io_type(outfile)
-            if io_type == IOType.STDOUT:
-                reporter = ConsoleReporter()
-                reporter.display(record)
-            elif io_type == IOType.FILE:
-                from nnbench.reporter.file import get_file_io_class
-
-                file_io = get_file_io_class(outfile)
-                file_io.write(record, outfile, {})
-            elif io_type == IOType.DATABASE:
-                raise NotImplementedError
-            elif io_type == IOType.SERVICE:
-                from nnbench.reporter.service import get_service_io_class
-
-                io = get_service_io_class(outfile)
-                io.write(record, outfile, {})
-            else:  # IOType.UNKNOWN
-                raise ValueError(f"unsupported URI format {outfile!r}")
+            io = get_io_implementation(outfile)
+            io.write(record, outfile, {})
         elif args.command == "compare":
             from nnbench.compare import compare
 

--- a/src/nnbench/reporter/__init__.py
+++ b/src/nnbench/reporter/__init__.py
@@ -4,38 +4,44 @@ files, databases, or web services.
 """
 
 import os
-from enum import Enum
-from typing import TextIO
 
+from ..util import get_protocol
 from .console import ConsoleReporter
-from .file import FileReporter
+from .file import BenchmarkFileIO, FileReporter
+from .service import BenchmarkServiceIO, MLFlowIO
+
+_io_implementations = {
+    "stdout": ConsoleReporter,
+    "s3": FileReporter,
+    "gs": FileReporter,
+    "gcs": FileReporter,
+    "az": FileReporter,
+    "lakefs": FileReporter,
+    "file": FileReporter,
+    "mlflow": MLFlowIO,
+}
 
 
-class IOType(str, Enum):
-    STDOUT = "stdout"
-    FILE = "file"
-    DATABASE = "database"
-    SERVICE = "service"  # TODO: Pick a better name
-    UNKNOWN = "unknown"
-
-
-def get_io_type(uri: str | os.PathLike[str] | TextIO) -> IOType:
+def get_io_implementation(uri: str | os.PathLike[str]) -> BenchmarkFileIO | BenchmarkServiceIO:
     import sys
 
     if uri is sys.stdout:
-        return IOType.STDOUT
-
-    from nnbench.util import get_protocol
-
-    proto = get_protocol(uri)
-    if proto in ["az", "file", "gcs", "gs", "lakefs", "s3"]:
-        return IOType.FILE
-    elif proto in ["sqlite"]:  # TODO: Not yet supported
-        return IOType.DATABASE
-    elif proto in ["mlflow"]:
-        return IOType.SERVICE
+        proto = "stdout"
     else:
-        return IOType.UNKNOWN
+        proto = get_protocol(uri)
+    try:
+        return _io_implementations[proto]()
+    except KeyError:
+        raise ValueError(f"unsupported benchmark IO protocol {proto!r}") from None
 
 
-del Enum, os, TextIO
+def register_io_implementation(name: str, klass: type, clobber: bool = False) -> None:
+    if name in _io_implementations and not clobber:
+        raise RuntimeError(
+            f"benchmark IO {name!r} is already registered "
+            f"(to force registration, rerun with clobber=True)"
+        )
+    _io_implementations[name] = klass
+
+
+del os

--- a/src/nnbench/reporter/console.py
+++ b/src/nnbench/reporter/console.py
@@ -1,9 +1,11 @@
 import json
+import os
 from typing import Any
 
 from rich.console import Console
 from rich.table import Table
 
+from nnbench.reporter.file import BenchmarkFileIO
 from nnbench.types import BenchmarkRecord
 
 _MISSING = "-----"
@@ -16,7 +18,7 @@ def get_value_by_name(result: dict[str, Any]) -> str:
     return str(result.get("value", _MISSING))
 
 
-class ConsoleReporter:
+class ConsoleReporter(BenchmarkFileIO):
     """
     The base interface for a console reporter class.
 
@@ -38,7 +40,15 @@ class ConsoleReporter:
         # TODO: Add context manager to register live console prints
         self.console = Console(**kwargs)
 
-    def display(self, record: BenchmarkRecord) -> None:
+    def read(self, fp: str | os.PathLike[str], options: dict[str, Any]) -> BenchmarkRecord:
+        raise NotImplementedError
+
+    def write(
+        self,
+        record: BenchmarkRecord,
+        outfile: str | os.PathLike[str] = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
         """
         Display a benchmark record in the console as a rich-text table.
 
@@ -52,7 +62,12 @@ class ConsoleReporter:
         ----------
         record: BenchmarkRecord
             The benchmark record to display.
+        outfile: str | os.PathLike[str]
+            For compatibility with the `BenchmarkFileIO` interface, unused.
+        options: dict[str, Any]
+            Display options used to format the resulting table.
         """
+        del outfile
         t = Table()
 
         rows: list[list[str]] = []

--- a/src/nnbench/reporter/file.py
+++ b/src/nnbench/reporter/file.py
@@ -230,8 +230,7 @@ class FileReporter:
             If the extension of the given file is not supported.
         """
 
-        ext = get_extension(file)
-        file_io = get_file_io_class(ext)
+        file_io = get_file_io_class(file)
         return file_io.read(file, options or {})
 
     def write(
@@ -259,6 +258,5 @@ class FileReporter:
         ValueError
             If the extension of the given file is not supported.
         """
-        ext = get_extension(file)
-        file_io = get_file_io_class(ext)
+        file_io = get_file_io_class(file)
         file_io.write(record, file, options or {})


### PR DESCRIPTION
This lets us skip all the unnecessary enum / type switching.

Also refactors the reporter portion to be a proper submodule without it being imported into the top-level. All docs examples are restructured accordingly.