### PR TITLE
cli: Allow provider names to be passed without "provider" key

### DIFF
--- a/docs/cli/pyproject.md
+++ b/docs/cli/pyproject.md
@@ -43,10 +43,10 @@ Any arguments needed to instantiate a context provider class can be given under 
 !!! Warning
     If you register a context provider *function*, you **must** leave the `arguments` key out of the above TOML table, since by definition, context providers do not take any arguments in their `__call__()` signature.
 
-Now we can use said provider in a benchmark run by passing the special `"provider"` key:
+Now we can use said provider in a benchmark run by passing just the provider name:
 
 ```commandline
-$ nnbench run benchmarks.py --context=provider=myctx
+$ nnbench run benchmarks.py --context=myctx
 Context values:
 {
     "python": {

--- a/src/nnbench/config.py
+++ b/src/nnbench/config.py
@@ -131,6 +131,9 @@ def import_(resource: str) -> Any:
     # If the current directory is not on sys.path, insert it in front.
     if "" not in sys.path and "." not in sys.path:
         sys.path.insert(0, "")
+
+    # NB: This assumes that every resource is a top-level member of the
+    # target module, and not nested in a class or other construct.
     modname, classname = resource.rsplit(".", 1)
     klass = getattr(importlib.import_module(modname), classname)
     return klass


### PR DESCRIPTION
This makes for an easier experience when adding a registered context provider on the command line.

Also refactors some utilities away from the implementation files.