### PR TITLE
refactor: Change date key and value type for benchmark timestamp

### DIFF
--- a/docs/cli/cli.md
+++ b/docs/cli/cli.md
@@ -100,7 +100,7 @@ Supposing we have the following records from previous runs, for a benchmark `add
       "name": "add",
       "function": "add",
       "description": "",
-      "date": "2024-12-02T17:41:16",
+      "timestamp": 1733157676,
       "error_occurred": false,
       "error_message": "",
       "parameters": {
@@ -128,7 +128,7 @@ and
       "name": "add",
       "function": "add",
       "description": "",
-      "date": "2024-12-02T17:42:04",
+      "timestamp": 1733157724,
       "error_occurred": false,
       "error_message": "",
       "parameters": {

--- a/src/nnbench/reporter/service.py
+++ b/src/nnbench/reporter/service.py
@@ -1,6 +1,5 @@
 import os
 from contextlib import ExitStack
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -67,7 +66,7 @@ class MLFlowIO(BenchmarkServiceIO):
         self.mlflow.log_dict(record.context, "context.json", run_id=run.info.run_id)
         for bm in record.benchmarks:
             name, value = bm["name"], bm["value"]
-            timestamp = int(datetime.fromisoformat(bm["date"]).timestamp())
+            timestamp = bm["timestamp"]
             self.mlflow.log_metric(name, value, timestamp=timestamp, run_id=run.info.run_id)
 
 

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -6,10 +6,10 @@ import logging
 import os
 import platform
 import sys
+import time
 import uuid
 from collections.abc import Callable, Iterable
 from dataclasses import asdict
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -234,7 +234,7 @@ def run(
             "name": benchmark.name,
             "function": qualname(benchmark.fn),
             "description": benchmark.fn.__doc__ or "",
-            "date": datetime.now().isoformat(timespec="seconds"),
+            "timestamp": int(time.time()),
             "error_occurred": False,
             "error_message": "",
             "parameters": jsonifier(bmparams),


### PR DESCRIPTION
The previous format as a datestring was opinionated and inflexible, and led to some quirks with mlflow reporting. Now, we just log the (integer) timestamp when a run was started, which can then be processed by whichever tool is processing the record.