### PR TITLE
cli: Add query to reporter.read interface, add URI support to compare

### DIFF
--- a/src/nnbench/context.py
+++ b/src/nnbench/context.py
@@ -13,18 +13,6 @@ ContextProvider = Callable[[], Context]
 """A function providing a dictionary of context values."""
 
 
-def system() -> dict[str, str]:
-    return {"system": platform.system()}
-
-
-def cpuarch() -> dict[str, str]:
-    return {"cpuarch": platform.machine()}
-
-
-def python_version() -> dict[str, str]:
-    return {"python_version": platform.python_version()}
-
-
 class PythonInfo:
     """
     A context helper returning version info for requested installed packages.

--- a/src/nnbench/reporter/__init__.py
+++ b/src/nnbench/reporter/__init__.py
@@ -9,7 +9,7 @@ from .console import ConsoleReporter
 from .file import BenchmarkFileIO, FileReporter
 from .service import BenchmarkServiceIO, MLFlowIO
 
-_io_implementations = {
+_known_reporters = {
     "stdout": ConsoleReporter,
     "s3": FileReporter,
     "gs": FileReporter,
@@ -21,7 +21,9 @@ _io_implementations = {
 }
 
 
-def get_io_implementation(uri: str | os.PathLike[str]) -> BenchmarkFileIO | BenchmarkServiceIO:
+def get_reporter_implementation(
+    uri: str | os.PathLike[str],
+) -> BenchmarkFileIO | BenchmarkServiceIO:
     import sys
 
     if uri is sys.stdout:
@@ -31,18 +33,18 @@ def get_io_implementation(uri: str | os.PathLike[str]) -> BenchmarkFileIO | Benc
 
         proto = get_protocol(uri)
     try:
-        return _io_implementations[proto]()
+        return _known_reporters[proto]()
     except KeyError:
         raise ValueError(f"unsupported benchmark IO protocol {proto!r}") from None
 
 
 def register_io_implementation(name: str, klass: type, clobber: bool = False) -> None:
-    if name in _io_implementations and not clobber:
+    if name in _known_reporters and not clobber:
         raise RuntimeError(
             f"benchmark IO {name!r} is already registered "
             f"(to force registration, rerun with clobber=True)"
         )
-    _io_implementations[name] = klass
+    _known_reporters[name] = klass
 
 
 del os

--- a/src/nnbench/reporter/file.py
+++ b/src/nnbench/reporter/file.py
@@ -182,8 +182,13 @@ def register_file_io_class(name: str, klass: type[BenchmarkFileIO], clobber: boo
 
 
 class FileReporter:
+    @staticmethod
+    def filter_open_kwds(kwargs: dict[str, Any]) -> dict[str, Any]:
+        _OPEN_KWDS = ("buffering", "encoding", "errors", "newline", "closefd", "opener")
+        return {k: v for k, v in kwargs.items() if k in _OPEN_KWDS}
+
+    @staticmethod
     def read(
-        self,
         file: str | os.PathLike[str],
         options: dict[str, Any] | None = None,
     ) -> BenchmarkRecord:
@@ -213,8 +218,8 @@ class FileReporter:
         file_io = get_file_io_class(file)
         return file_io.read(file, options or {})
 
+    @staticmethod
     def write(
-        self,
         record: BenchmarkRecord,
         file: str | os.PathLike[str],
         options: dict[str, Any] | None = None,

--- a/src/nnbench/reporter/service.py
+++ b/src/nnbench/reporter/service.py
@@ -3,7 +3,6 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
-from nnbench.reporter.util import get_protocol
 from nnbench.types import BenchmarkRecord
 
 if TYPE_CHECKING:
@@ -11,7 +10,9 @@ if TYPE_CHECKING:
 
 
 class BenchmarkServiceIO(Protocol):
-    def read(self, uri: str | os.PathLike[str], options: dict[str, Any]) -> BenchmarkRecord: ...
+    def read(
+        self, uri: str | os.PathLike[str], query: str | None, options: dict[str, Any]
+    ) -> BenchmarkRecord: ...
 
     def write(
         self, record: BenchmarkRecord, uri: str | os.PathLike[str], options: dict[str, Any]
@@ -42,7 +43,9 @@ class MLFlowIO(BenchmarkServiceIO):
         else:
             return self.mlflow.start_run(run_name=run_name, nested=nested)
 
-    def read(self, uri: str | os.PathLike[str], options: dict[str, Any]) -> BenchmarkRecord:
+    def read(
+        self, uri: str | os.PathLike[str], query: str | None, options: dict[str, Any]
+    ) -> BenchmarkRecord:
         raise NotImplementedError
 
     def write(
@@ -52,44 +55,20 @@ class MLFlowIO(BenchmarkServiceIO):
         try:
             experiment, run_name, *subruns = Path(uri).parts
         except ValueError:
-            raise ValueError(f"expected URI of form <experiment>/<run>[/<subrun>]..., got {uri!r}")
+            raise ValueError(f"expected URI of form <experiment>/<run>[/<subrun>...], got {uri!r}")
 
         # setting experiment removes the need for passing the `experiment_id` kwarg
         # in the subsequent API calls.
-        self.mlflow.set_experiment(experiment_name=experiment)
+        self.mlflow.set_experiment(experiment)
 
         run = self.stack.enter_context(self.get_or_create_run(run_name=run_name))
         for s in subruns:
             # reassignment ensures that we log into the max-depth subrun specified.
             run = self.stack.enter_context(self.get_or_create_run(run_name=s, nested=True))
 
-        self.mlflow.log_dict(record.context, "context.json", run_id=run.info.run_id)
+        run_id = run.info.run_id
+        self.mlflow.log_dict(record.context, "context.json", run_id=run_id)
         for bm in record.benchmarks:
             name, value = bm["name"], bm["value"]
             timestamp = bm["timestamp"]
-            self.mlflow.log_metric(name, value, timestamp=timestamp, run_id=run.info.run_id)
-
-
-# TODO: Investigate if this can be merged with the file io mapping to a top-level struct
-#  (e.g. with a value union type BenchmarkFileIO | BenchmarkServiceIO | ...)
-_service_io_mapping: dict[str, type[BenchmarkServiceIO]] = {
-    "mlflow": MLFlowIO,
-}
-
-
-def get_service_io_class(uri: str) -> BenchmarkServiceIO:
-    proto = get_protocol(uri)
-    try:
-        return _service_io_mapping[proto]()
-    except KeyError:
-        raise ValueError(f"unsupported benchmark IO: {proto!r}") from None
-
-
-def register_file_io_class(
-    name: str, klass: type[BenchmarkServiceIO], clobber: bool = False
-) -> None:
-    if name in _service_io_mapping and not clobber:
-        raise RuntimeError(
-            f"IO {name!r} is already registered (to force registration, rerun with clobber=True)"
-        )
-    _service_io_mapping[name] = klass
+            self.mlflow.log_metric(name, value, timestamp=timestamp, run_id=run_id)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 import nnbench
-from nnbench.context import cpuarch, python_version, system
 
 
 def test_runner_collection(testfolder: str) -> None:
@@ -26,32 +25,26 @@ def test_tag_selection(testfolder: str) -> None:
 
 
 def test_context_assembly(testfolder: str) -> None:
-    context_providers = [system, cpuarch, python_version]
     benchmarks = nnbench.collect(testfolder, tags=("standard",))
     result = nnbench.run(
         benchmarks,
         params={"x": 1, "y": 1},
-        context=context_providers,
+        context=[lambda: {"foo": "bar"}],
     )
 
-    ctx = result.context
-    assert "system" in ctx
-    assert "cpuarch" in ctx
-    assert "python_version" in ctx
+    assert "foo" in result.context
 
 
 def test_error_on_duplicate_context_keys_in_runner(testfolder: str) -> None:
-    def duplicate_context_provider() -> dict[str, str]:
-        return {"system": "DuplicateSystem"}
-
-    context_providers = [system, duplicate_context_provider]
+    def duplicate_provider() -> dict[str, str]:
+        return {"foo": "baz"}
 
     benchmarks = nnbench.collect(testfolder, tags=("standard",))
-    with pytest.raises(ValueError, match="got multiple values for context key 'system'"):
+    with pytest.raises(ValueError, match="got multiple values for context key 'foo'"):
         nnbench.run(
             benchmarks,
             params={"x": 1, "y": 1},
-            context=context_providers,
+            context=[lambda: {"foo": "bar"}, duplicate_provider],
         )
 
 


### PR DESCRIPTION
The query field in `IO.read()` allows us to send data queries to database-like IO interfaces, such as that of most experiment trackers and databases themselves.

The URI support was taken over verbatim from the already working bit in `nnbench run`.

-------------------

Also removes some copied code from `nnbench.reporter.service`.

I'm wondering if it's not worth stabilizing the Reporter interface again with `query: str | None`, and just ignore the query for anything file/stream-based. Would probably save a lot of headache.