### PR TITLE
chore: Rename BenchmarkRecord -> BenchmarkResult, add `(to|from)_reco…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ reporter = ConsoleReporter()
 # first, collect the above benchmarks directly from the current module...
 benchmarks = nnbench.collect("__main__")
 # ... then run the benchmarks with the parameters `a=2, b=10`...
-record = nnbench.run(benchmarks, params={"a": 2, "b": 10})
-reporter.write(record)  # ...and print the results to the terminal.
+result = nnbench.run(benchmarks, params={"a": 2, "b": 10})
+reporter.write(result)  # ...and print the results to the terminal.
 
 # results in a table look like the following:
 # ┏━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓

--- a/docs/cli/cli.md
+++ b/docs/cli/cli.md
@@ -71,10 +71,10 @@ To create a comparison table between multiple benchmark runs, use the `nnbench c
 
 ```commandline
 $ nnbench compare -h                                            
-usage: nnbench compare [-h] [-P <name>] [-C <name>] [-E <name>] records [records ...]
+usage: nnbench compare [-h] [-P <name>] [-C <name>] [-E <name>] results [results ...]
 
 positional arguments:
-  records               Records to compare results for. Can be given as local files or remote URIs.
+  results               Results to compare. Can be given as local files or remote URIs.
 
 options:
   -h, --help            show this help message and exit
@@ -83,13 +83,13 @@ options:
   -C, --include-context <name>
                         Context values to display in the comparison table. Use dotted syntax for nested context values.
   -E, --extra-column <name>
-                        Additional record data to display in the comparison table.
+                        Additional result data to display in the comparison table.
 ```
 
-Supposing we have the following records from previous runs, for a benchmark `add(a,b)` that adds two integers:
+Supposing we have the following results from previous runs, for a benchmark `add(a,b)` that adds two integers:
 
 ```json
-// Pretty-printed JSON, obtained as <record1.json | jq
+// Pretty-printed JSON, obtained as <result1.json | jq
 {
   "run": "nnbench-3ff188b4",
   "context": {
@@ -117,7 +117,7 @@ Supposing we have the following records from previous runs, for a benchmark `add
 and
 
 ```json
-// <record2.json | jq
+// <result2.json | jq
 {
   "run": "nnbench-5cbb85f8",
   "context": {
@@ -142,10 +142,10 @@ and
 },
 ```
 
-we can compare them in a table view by running `nnnbench compare record1.json record2.json`:
+we can compare them in a table view by running `nnnbench compare result1.json result2.json`:
 
 ```commandline
-$ nnbench compare record1.json record2.json
+$ nnbench compare result1.json result2.json
 ┏━━━━━━━━━━━━━━━━━━┳━━━━━┓
 ┃ Benchmark run    ┃ add ┃
 ┡━━━━━━━━━━━━━━━━━━╇━━━━━┩
@@ -158,7 +158,7 @@ To include benchmark parameter values in the table, use the `-P` switch (you can
 For example, to see which values were used for `a` and `b` in our `add(a, b)` benchmark above, we supply `-P a` and `-P b`:
 
 ```commandline
-$ nnbench compare record1.json record2.json -P a -P b
+$ nnbench compare result1.json result2.json -P a -P b
 ┏━━━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
 ┃ Benchmark run    ┃ add ┃ Params->a ┃ Params->b ┃
 ┡━━━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
@@ -170,7 +170,7 @@ $ nnbench compare record1.json record2.json -P a -P b
 To include context values in the table - in our case, we might want to display the `foo` value - use the `-C` switch (this is also appending, same as `-P`):
 
 ```commandline
-$ nnbench compare record1.json record2.json -P a -P b -C foo
+$ nnbench compare result1.json result2.json -P a -P b -C foo
 ┏━━━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━┓
 ┃ Benchmark run    ┃ add ┃ Params->a ┃ Params->b ┃ foo ┃
 ┡━━━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━┩

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,8 +48,8 @@ from nnbench.reporter import ConsoleReporter
 benchmarks = nnbench.collect("__main__")
 reporter = ConsoleReporter()
 # To collect in the current file, pass "__main__" as module name.
-record = nnbench.run(benchmarks, params={"model": model, "X_test": X_test, "y_test": y_test})
-reporter.write(record)
+result = nnbench.run(benchmarks, params={"model": model, "X_test": X_test, "y_test": y_test})
+reporter.write(result)
 ```
 
 The resulting output might look like this:

--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -217,11 +217,12 @@ def mnist_jax():
     state, data = train(mnist)
 
     # the nnbench portion.
+    i = 3
     benchmarks = nnbench.collect(HERE)
     reporter = FileReporter()
     params = MNISTTestParameters(params=state.params, data=data)
-    result = nnbench.run(benchmarks, params=params)
-    reporter.write(result, "result.json")
+    result = nnbench.run(benchmarks, name=f"run{i}", params=params)
+    reporter.write(result, f"result{i}.json")
 
 
 if __name__ == "__main__":

--- a/examples/streamlit/streamlit_example.py
+++ b/examples/streamlit/streamlit_example.py
@@ -41,12 +41,12 @@ async def run_bms(params: dict[str, Any]) -> str:
 def get_bm_artifacts(storage_key: str) -> None:
     blob_path = LOCAL_PREFECT_PERSISTENCE_FOLDER / storage_key
     blob = PersistedResultBlob.parse_raw(blob_path.read_bytes())
-    bm_records: tuple[nnbench.BenchmarkRecord, ...] = pickle.loads(base64.b64decode(blob.data))
+    bm_results: tuple[nnbench.BenchmarkResult, ...] = pickle.loads(base64.b64decode(blob.data))
 
-    bms = [pd.DataFrame(record.benchmarks) for record in bm_records]
+    bms = [pd.DataFrame(result.benchmarks) for result in bm_results]
     for df in bms:
         df["value"] = df["value"].apply(lambda x: f"{x:.2e}")
-    cxs = [pd.DataFrame([record.context.data]) for record in bm_records]
+    cxs = [pd.DataFrame([result.context.data]) for result in bm_results]
 
     display_data = [bms + [cxs[0]]]  # Only need context once
     st.session_state["benchmarks"].extend(display_data)

--- a/src/nnbench/__init__.py
+++ b/src/nnbench/__init__.py
@@ -2,6 +2,6 @@
 
 from .core import benchmark, parametrize, product
 from .runner import collect, run
-from .types import Benchmark, BenchmarkFamily, BenchmarkRecord, Parameters
+from .types import Benchmark, BenchmarkFamily, BenchmarkResult, Parameters
 
 __version__ = "0.4.0"

--- a/src/nnbench/reporter/console.py
+++ b/src/nnbench/reporter/console.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.table import Table
 
 from nnbench.reporter.file import BenchmarkFileIO
-from nnbench.types import BenchmarkRecord
+from nnbench.types import BenchmarkResult
 
 _MISSING = "-----"
 
@@ -40,28 +40,28 @@ class ConsoleReporter(BenchmarkFileIO):
         # TODO: Add context manager to register live console prints
         self.console = Console(**kwargs)
 
-    def read(self, fp: str | os.PathLike[str], options: dict[str, Any]) -> BenchmarkRecord:
+    def read(self, fp: str | os.PathLike[str], options: dict[str, Any]) -> BenchmarkResult:
         raise NotImplementedError
 
     def write(
         self,
-        record: BenchmarkRecord,
+        result: BenchmarkResult,
         outfile: str | os.PathLike[str] = None,
         options: dict[str, Any] | None = None,
     ) -> None:
         """
-        Display a benchmark record in the console as a rich-text table.
+        Display a benchmark result in the console as a rich-text table.
 
         Gives a summary of all present context values directly above the table,
-        as a pretty-printed JSON record.
+        as a pretty-printed JSON result.
 
         By default, displays only the benchmark name, value, execution wall time,
         and parameters.
 
         Parameters
         ----------
-        record: BenchmarkRecord
-            The benchmark record to display.
+        result: BenchmarkResult
+            The benchmark result to display.
         outfile: str | os.PathLike[str]
             For compatibility with the `BenchmarkFileIO` interface, unused.
         options: dict[str, Any]
@@ -75,9 +75,9 @@ class ConsoleReporter(BenchmarkFileIO):
 
         # print context values
         print("Context values:")
-        print(json.dumps(record.context, indent=4))
+        print(json.dumps(result.context, indent=4))
 
-        for bm in record.benchmarks:
+        for bm in result.benchmarks:
             row = [bm["name"], get_value_by_name(bm), str(bm["time_ns"]), str(bm["parameters"])]
             rows.append(row)
 

--- a/src/nnbench/reporter/service.py
+++ b/src/nnbench/reporter/service.py
@@ -3,7 +3,7 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
-from nnbench.types import BenchmarkRecord
+from nnbench.types import BenchmarkResult
 
 if TYPE_CHECKING:
     from mlflow import ActiveRun as ActiveRun
@@ -12,10 +12,10 @@ if TYPE_CHECKING:
 class BenchmarkServiceIO(Protocol):
     def read(
         self, uri: str | os.PathLike[str], query: str | None, options: dict[str, Any]
-    ) -> BenchmarkRecord: ...
+    ) -> BenchmarkResult: ...
 
     def write(
-        self, record: BenchmarkRecord, uri: str | os.PathLike[str], options: dict[str, Any]
+        self, record: BenchmarkResult, uri: str | os.PathLike[str], options: dict[str, Any]
     ) -> None: ...
 
 
@@ -45,11 +45,11 @@ class MLFlowIO(BenchmarkServiceIO):
 
     def read(
         self, uri: str | os.PathLike[str], query: str | None, options: dict[str, Any]
-    ) -> BenchmarkRecord:
+    ) -> BenchmarkResult:
         raise NotImplementedError
 
     def write(
-        self, record: BenchmarkRecord, uri: str | os.PathLike[str], options: dict[str, Any]
+        self, record: BenchmarkResult, uri: str | os.PathLike[str], options: dict[str, Any]
     ) -> None:
         uri = self.strip_protocol(uri)
         try:

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from nnbench.reporter.file import get_file_io_class
-from nnbench.types import BenchmarkRecord
+from nnbench.types import BenchmarkResult
 
 
 @pytest.mark.parametrize(
@@ -13,12 +13,13 @@ from nnbench.types import BenchmarkRecord
 def test_fileio_writes_no_compression_inline(tmp_path: Path, ext: str) -> None:
     """Tests data integrity for file IO roundtrips with both context modes."""
 
-    rec = BenchmarkRecord(
+    rec = BenchmarkResult(
         run="my-run",
         context={"a": "b", "s": 1, "b.c": 1.0},
         benchmarks=[{"name": "foo", "value": 1}, {"name": "bar", "value": 2}],
+        timestamp=0,
     )
-    file = tmp_path / f"record.{ext}"
+    file = tmp_path / f"result.{ext}"
     f = get_file_io_class(file)
     f.write(rec, file, {})
     rec2 = f.read(file, {})


### PR DESCRIPTION
…rds` API

This was an unfortunate misnomer for us, since we want to stream benchmark results (i.e. metrics) to and from databases too, and in that context, the "record" nomenclature is more fitting for a single row (i.e., a single benchmark output).

Hence, do the aforementioned rename to avoid ambiguity.