### PR TITLE
feat: Add SQLite reporter

### DIFF
--- a/src/nnbench/compare.py
+++ b/src/nnbench/compare.py
@@ -133,7 +133,7 @@ class TabularComparison(AbstractComparison):
         self.placeholder = placeholder
         self.comparators = comparators or {}
 
-        self.results: list[BenchmarkResult] = list(results)
+        self.results: list[BenchmarkResult] = list(*results)
         self.data: list[dict[str, Any]] = [make_row(rec) for rec in self.results]
         self.metrics: list[str] = []
         self._success: bool = False
@@ -190,15 +190,18 @@ class TabularComparison(AbstractComparison):
         c = Console()
         t = Table()
 
-        if self.comparators:
+        has_comparable_metrics = set(self.metrics) & self.comparators.keys()
+        if has_comparable_metrics:
             c.print("Comparison strategy: All vs. first")
             c.print("Comparisons:")
             for k, v in self.comparators.items():
                 c.print(f"    {k}: {v}")
+        else:
+            print(f"warning: no comparators found for metrics {', '.join(self.metrics)}")
 
         rows: list[list[str]] = []
         columns: list[str] = ["Run Name"] + list(self.display_names.values())
-        if set(self.metrics) | self.comparators.keys():
+        if has_comparable_metrics:
             columns += ["Status"]
 
         for i, d in enumerate(self.data):

--- a/src/nnbench/reporter/console.py
+++ b/src/nnbench/reporter/console.py
@@ -5,8 +5,7 @@ from typing import Any
 from rich.console import Console
 from rich.table import Table
 
-from nnbench.reporter.file import BenchmarkFileIO
-from nnbench.types import BenchmarkResult
+from nnbench.types import BenchmarkReporter, BenchmarkResult
 
 _MISSING = "-----"
 
@@ -18,7 +17,7 @@ def get_value_by_name(result: dict[str, Any]) -> str:
     return str(result.get("value", _MISSING))
 
 
-class ConsoleReporter(BenchmarkFileIO):
+class ConsoleReporter(BenchmarkReporter):
     """
     The base interface for a console reporter class.
 

--- a/src/nnbench/reporter/sqlite.py
+++ b/src/nnbench/reporter/sqlite.py
@@ -1,0 +1,55 @@
+import os
+import sqlite3
+from typing import Any
+
+from nnbench import BenchmarkResult
+from nnbench.types import BenchmarkReporter
+
+# TODO: Add tablename state (f-string)
+_DEFAULT_COLS = ("run", "benchmark", "context", "timestamp")
+_DEFAULT_CREATION_QUERY = "CREATE TABLE IF NOT EXISTS nnbench(" + ", ".join(_DEFAULT_COLS) + ")"
+_DEFAULT_INSERT_QUERY = "INSERT INTO nnbench VALUES(:run, :benchmark, :context, :timestamp)"
+_DEFAULT_READ_QUERY = """SELECT * FROM nnbench"""
+
+
+class SQLiteReporter(BenchmarkReporter):
+    @staticmethod
+    def strip_protocol(uri: str | os.PathLike[str]) -> str:
+        s = str(uri)
+        if s.startswith("sqlite://"):
+            return s[9:]
+        return s
+
+    def read(self, uri: str | os.PathLike[str], options: dict[str, Any]) -> BenchmarkResult:
+        uri = self.strip_protocol(uri)
+        query: str | None = options.pop("query", _DEFAULT_READ_QUERY)
+        if query is None:
+            raise ValueError(f"need a query to read from SQLite Database {uri!r}")
+
+        db = f"file:{uri}?mode=ro"  # open DB in read-only mode
+        conn = sqlite3.connect(db, uri=True)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.execute(query)
+        records = [dict(r) for r in cursor.fetchall()]
+        conn.close()
+        # TODO: Partition list on run ID, make record for each of them
+        return BenchmarkResult.from_records(records)
+
+    def write(
+        self, result: BenchmarkResult, uri: str | os.PathLike[str], options: dict[str, Any]
+    ) -> None:
+        uri = self.strip_protocol(uri)
+        query: str | None = options.pop("query", _DEFAULT_INSERT_QUERY)
+        if query is None:
+            raise ValueError(f"need a query to write to SQLite Database {uri!r}")
+
+        conn = sqlite3.connect(uri)
+        cursor = conn.cursor()
+
+        # TODO: Guard by exists_ok state
+        cursor.execute(_DEFAULT_CREATION_QUERY)
+
+        records = result.to_records()
+        cursor.executemany(query, records)
+        conn.commit()

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -23,10 +23,11 @@ def test_fileio_writes_no_compression_inline(tmp_path: Path, ext: str) -> None:
     f = get_file_io_class(file)
     f.write(rec, file, {})
     rec2 = f.read(file, {})
-    # Python stdlib csv coerces everything to string.
+    if isinstance(rec2, list):
+        rec2 = rec2[0]
     if ext == "csv":
         for bm1, bm2 in zip(rec.benchmarks, rec2.benchmarks):
             assert bm1.keys() == bm2.keys()
-            assert set(map(str, bm1.values())) == set(bm2.values())
+            assert set(bm1.values()) == set(bm2.values())
     else:
         assert rec2 == rec


### PR DESCRIPTION
Responsible for reading and writing results to SQLite databases.

This requires a tweak to `BenchmarkResult.from_records()`, because in principle, an SQLite query result can contain an arbitrary number of runs (and so can files for that matter). Thus, the return type is changed to yield a list of benchmarks.

Usage: nnbench run benchmarks.py -o sqlite://my-database.db.