### PR TITLE
fix: Collapse results when loading them into comparison

### DIFF
--- a/examples/mnist/mnist.py
+++ b/examples/mnist/mnist.py
@@ -217,12 +217,11 @@ def mnist_jax():
     state, data = train(mnist)
 
     # the nnbench portion.
-    i = 3
     benchmarks = nnbench.collect(HERE)
     reporter = FileReporter()
     params = MNISTTestParameters(params=state.params, data=data)
-    result = nnbench.run(benchmarks, name=f"run{i}", params=params)
-    reporter.write(result, f"result{i}.json")
+    result = nnbench.run(benchmarks, name="nnbench-mnist-run", params=params)
+    reporter.write(result, "mnist-result.json")
 
 
 if __name__ == "__main__":

--- a/src/nnbench/compare.py
+++ b/src/nnbench/compare.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from nnbench.types import BenchmarkResult
+from nnbench.util import collapse
 
 _MISSING = "N/A"
 _STATUS_KEY = "Status"
@@ -121,7 +122,7 @@ class TabularComparison(AbstractComparison):
 
         Parameters
         ----------
-        results: Sequence[BenchmarkResult]
+        results: Iterable[BenchmarkResult]
             The benchmark results to compare.
         comparators: dict[str, Comparator]
             A mapping from benchmark functions to comparators, i.e. a function
@@ -132,8 +133,7 @@ class TabularComparison(AbstractComparison):
         """
         self.placeholder = placeholder
         self.comparators = comparators or {}
-
-        self.results: list[BenchmarkResult] = list(*results)
+        self.results: tuple[BenchmarkResult, ...] = tuple(collapse(results))
         self.data: list[dict[str, Any]] = [make_row(rec) for rec in self.results]
         self.metrics: list[str] = []
         self._success: bool = False
@@ -215,7 +215,7 @@ class TabularComparison(AbstractComparison):
                     cd = self.data[0]
                     compval = cd.get(metric, self.placeholder)
                     success = self.compare2(metric, val, compval)
-                    self._success |= success
+                    self._success &= success
                     status += ":white_check_mark:" if success else ":x:"
                     sval += " (vs. " + self.format_value(metric, compval) + ")"
                 row += [sval]


### PR DESCRIPTION
This way, we do not have to deal with record lists coming from database queries explicitly.

Also reverts an accidental change to the MNIST example.