### PR TITLE
fix: Set success to True by default to make boolean additions correct

### DIFF
--- a/src/nnbench/compare.py
+++ b/src/nnbench/compare.py
@@ -124,7 +124,7 @@ class TabularComparison(AbstractComparison):
         ----------
         results: Iterable[BenchmarkResult]
             The benchmark results to compare.
-        comparators: dict[str, Comparator]
+        comparators: dict[str, Comparator] | None
             A mapping from benchmark functions to comparators, i.e. a function
             comparing two results and returning a boolean indicating a favourable or
             unfavourable comparison.
@@ -136,7 +136,7 @@ class TabularComparison(AbstractComparison):
         self.results: tuple[BenchmarkResult, ...] = tuple(collapse(results))
         self.data: list[dict[str, Any]] = [make_row(rec) for rec in self.results]
         self.metrics: list[str] = []
-        self._success: bool = False
+        self._success: bool = True
 
         self.display_names: dict[str, str] = {}
         for res in self.results:

--- a/src/nnbench/reporter/mlflow.py
+++ b/src/nnbench/reporter/mlflow.py
@@ -55,8 +55,8 @@ class MLFlowReporter(BenchmarkReporter):
             run = self.stack.enter_context(self.get_or_create_run(run_name=s, nested=True))
 
         run_id = run.info.run_id
+        timestamp = result.timestamp
         self.mlflow.log_dict(result.context, "context.json", run_id=run_id)
         for bm in result.benchmarks:
             name, value = bm["name"], bm["value"]
-            timestamp = bm["timestamp"]
             self.mlflow.log_metric(name, value, timestamp=timestamp, run_id=run_id)


### PR DESCRIPTION
With a `False` default, val1 & val2 can never produce a non-zero exit code even if all checks were satisfied.

Also, fix the MLflow reporter by obtaining the timestamp from the result instead of the benchmark.