### PR TITLE
refactor: Revert to single result writing in reporter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,19 +10,19 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.0
     hooks:
      - id: mypy
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --explicit-package-bases]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.11.12
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.7.6
+    rev: 0.7.8
     hooks:
       - id: uv-lock
         name: Lock project dependencies

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -293,7 +293,7 @@ def main(argv: list[str] | None = None) -> int:
 
             outfile = args.outfile
             reporter = get_reporter_implementation(outfile)
-            reporter.write([result], outfile)
+            reporter.write(result, outfile)
         elif args.command == "compare":
             from nnbench.compare import TabularComparison
 

--- a/src/nnbench/compare.py
+++ b/src/nnbench/compare.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from nnbench.types import BenchmarkResult
-from nnbench.util import collapse
+from nnbench.util import collate
 
 _MISSING = "N/A"
 _STATUS_KEY = "Status"
@@ -133,7 +133,7 @@ class TabularComparison(AbstractComparison):
         """
         self.placeholder = placeholder
         self.comparators = comparators or {}
-        self.results: tuple[BenchmarkResult, ...] = tuple(collapse(results))
+        self.results: tuple[BenchmarkResult, ...] = tuple(collate(results))
         self.data: list[dict[str, Any]] = [make_row(rec) for rec in self.results]
         self.metrics: list[str] = []
         self._success: bool = True

--- a/src/nnbench/reporter/mlflow.py
+++ b/src/nnbench/reporter/mlflow.py
@@ -1,5 +1,4 @@
 import os
-from collections.abc import Iterable
 from contextlib import ExitStack
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -37,7 +36,10 @@ class MLFlowReporter(BenchmarkReporter):
         raise NotImplementedError
 
     def write(
-        self, results: Iterable[BenchmarkResult], uri: str | os.PathLike[str], **kwargs: Any
+        self,
+        result: BenchmarkResult,
+        uri: str | os.PathLike[str],
+        **kwargs: Any,
     ) -> None:
         import mlflow
 
@@ -57,7 +59,7 @@ class MLFlowReporter(BenchmarkReporter):
             run = self.stack.enter_context(self.get_or_create_run(run_name=s, nested=True))
 
         run_id = run.info.run_id
-        for res in results:
+        for res in result:
             timestamp = res.timestamp
             mlflow.log_dict(res.context, f"context-{res.run}.json", run_id=run_id)
             for bm in res.benchmarks:

--- a/src/nnbench/runner.py
+++ b/src/nnbench/runner.py
@@ -18,7 +18,7 @@ from nnbench.fixtures import FixtureManager
 from nnbench.types import Benchmark, BenchmarkFamily, BenchmarkResult, Parameters, State
 from nnbench.util import (
     all_python_files,
-    collapse,
+    collate,
     exists_module,
     import_file_as_module,
     qualname,
@@ -201,7 +201,7 @@ def run(
     results: list[dict[str, Any]] = []
     timestamp = int(time.time())
 
-    for benchmark in collapse(benchmarks):
+    for benchmark in collate(benchmarks):
         bm_family = benchmark.interface.funcname
         state = State(
             name=benchmark.name,

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -137,10 +137,12 @@ class BenchmarkResult:
 
 
 class BenchmarkReporter(Protocol):
-    def read(self, fp: str | os.PathLike[str], **kwargs: Any) -> list[BenchmarkResult]: ...
+    def read(
+        self, fp: str | os.PathLike[str], **kwargs: Any
+    ) -> BenchmarkResult | list[BenchmarkResult]: ...
 
     def write(
-        self, results: Iterable[BenchmarkResult], fp: str | os.PathLike[str], **kwargs: Any
+        self, results: BenchmarkResult, fp: str | os.PathLike[str], **kwargs: Any
     ) -> None: ...
 
 

--- a/src/nnbench/util.py
+++ b/src/nnbench/util.py
@@ -15,7 +15,7 @@ from typing import Any, TypeVar
 T = TypeVar("T")
 
 
-def collapse(_its: Iterable[T | Iterable[T]]) -> Generator[T, None, None]:
+def collate(_its: Iterable[T | Iterable[T]]) -> Generator[T, None, None]:
     for _it in _its:
         if isinstance(_it, Iterable):
             yield from _it

--- a/tests/test_file_reporter.py
+++ b/tests/test_file_reporter.py
@@ -21,7 +21,7 @@ def test_file_reporter_roundtrip(tmp_path: Path, ext: str) -> None:
     )
     file = tmp_path / f"result.{ext}"
     f = FileReporter()
-    f.write([res], file)
+    f.write(res, file)
     (res2,) = f.read(file)
 
     if ext == "csv":

--- a/uv.lock
+++ b/uv.lock
@@ -253,11 +253,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2025.5.0"
+version = "2025.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/77/deb99b97981e2e191913454da82d406702405178631c31cd623caebaf1b1/fsspec-2025.5.0.tar.gz", hash = "sha256:e4f4623bb6221f7407fd695cc535d1f857a077eb247580f4ada34f5dc25fd5c8", size = 300989, upload-time = "2025-05-20T15:46:22.484Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/f7/27f15d41f0ed38e8fcc488584b57e902b331da7f7c6dcda53721b15838fc/fsspec-2025.5.1.tar.gz", hash = "sha256:2e55e47a540b91843b755e83ded97c6e897fa0942b11490113f09e9c443c2475", size = 303033, upload-time = "2025-05-24T12:03:23.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/a9/a7022f58e081149ec0184c31ea81dcee605e1d46380b48122e1ef94ac24e/fsspec-2025.5.0-py3-none-any.whl", hash = "sha256:0ca253eca6b5333d8a2b8bd98c7326fe821f1f0fdbd34e1b445bddde8e804c95", size = 196164, upload-time = "2025-05-20T15:46:20.89Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/61/78c7b3851add1481b048b5fdc29067397a1784e2910592bc81bb3f608635/fsspec-2025.5.1-py3-none-any.whl", hash = "sha256:24d3a2e663d5fc735ab256263c4075f374a174c3410c0b25e5bd1970bceaa462", size = 199052, upload-time = "2025-05-24T12:03:21.66Z" },
 ]
 
 [[package]]
@@ -323,11 +323,11 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.10"
+version = "2.6.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/83/b6ea0334e2e7327084a46aaaf71f2146fc061a192d6518c0d020120cd0aa/identify-2.6.10.tar.gz", hash = "sha256:45e92fd704f3da71cc3880036633f48b4b7265fd4de2b57627cb157216eb7eb8", size = 99201, upload-time = "2025-04-19T15:10:38.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254, upload-time = "2025-05-23T20:37:53.3Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/d3/85feeba1d097b81a44bcffa6a0beab7b4dfffe78e82fc54978d3ac380736/identify-2.6.10-py2.py3-none-any.whl", hash = "sha256:5f34248f54136beed1a7ba6a6b5c4b6cf21ff495aac7c359e1ef831ae3b8ab25", size = 99101, upload-time = "2025-04-19T15:10:36.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/cd/18f8da995b658420625f7ef13f037be53ae04ec5ad33f9b718240dcfd48c/identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2", size = 99145, upload-time = "2025-05-23T20:37:51.495Z" },
 ]
 
 [[package]]
@@ -735,7 +735,7 @@ python = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.16.10"
+version = "1.16.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffe" },
@@ -743,9 +743,9 @@ dependencies = [
     { name = "mkdocstrings" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/c8/600c4201b6b9e72bab16802316d0c90ce04089f8e6bb5e064cd2a5abba7e/mkdocstrings_python-1.16.10.tar.gz", hash = "sha256:f9eedfd98effb612ab4d0ed6dd2b73aff6eba5215e0a65cea6d877717f75502e", size = 205771, upload-time = "2025-04-03T14:24:48.12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/a3/0c7559a355fa21127a174a5aa2d3dca2de6e479ddd9c63ca4082d5f9980c/mkdocstrings_python-1.16.11.tar.gz", hash = "sha256:935f95efa887f99178e4a7becaaa1286fb35adafffd669b04fd611d97c00e5ce", size = 205392, upload-time = "2025-05-24T10:41:32.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/37/19549c5e0179785308cc988a68e16aa7550e4e270ec8a9878334e86070c6/mkdocstrings_python-1.16.10-py3-none-any.whl", hash = "sha256:63bb9f01f8848a644bdb6289e86dc38ceddeaa63ecc2e291e3b2ca52702a6643", size = 124112, upload-time = "2025-04-03T14:24:46.561Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c4/ffa32f2c7cdb1728026c7a34aab87796b895767893aaa54611a79b4eef45/mkdocstrings_python-1.16.11-py3-none-any.whl", hash = "sha256:25d96cc9c1f9c272ea1bd8222c900b5f852bf46c984003e9c7c56eaa4696190f", size = 124282, upload-time = "2025-05-24T10:41:30.008Z" },
 ]
 
 [[package]]
@@ -1365,9 +1365,9 @@ wheels = [
 
 [[package]]
 name = "zipp"
-version = "3.21.0"
+version = "3.22.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545, upload-time = "2024-11-10T15:05:20.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/b6/7b3d16792fdf94f146bed92be90b4eb4563569eca91513c8609aebf0c167/zipp-3.22.0.tar.gz", hash = "sha256:dd2f28c3ce4bc67507bfd3781d21b7bb2be31103b51a4553ad7d90b84e57ace5", size = 25257, upload-time = "2025-05-26T14:46:32.217Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630, upload-time = "2024-11-10T15:05:19.275Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/da/f64669af4cae46f17b90798a827519ce3737d31dbafad65d391e49643dc4/zipp-3.22.0-py3-none-any.whl", hash = "sha256:fe208f65f2aca48b81f9e6fd8cf7b8b32c26375266b009b413d45306b6148343", size = 9796, upload-time = "2025-05-26T14:46:30.775Z" },
 ]


### PR DESCRIPTION
It's more natural to let the user write results in a loop, since CLI invocations will typically produce only a single result.

Also removes a large portion of the legacy file reporter code.