### PR TITLE
fix: Rename output path argument to "path", fix MLflow reporter

### DIFF
--- a/src/nnbench/reporter/console.py
+++ b/src/nnbench/reporter/console.py
@@ -8,6 +8,7 @@ from rich.table import Table
 from nnbench.types import BenchmarkReporter, BenchmarkResult
 
 _MISSING = "-----"
+_STDOUT = "-"
 
 
 def get_value_by_name(result: dict[str, Any]) -> str:
@@ -40,14 +41,14 @@ class ConsoleReporter(BenchmarkReporter):
         self.console = Console(**kwargs)
 
     def read(
-        self, fp: str | os.PathLike[str], **kwargs: Any
+        self, path: str | os.PathLike[str], **kwargs: Any
     ) -> BenchmarkResult | list[BenchmarkResult]:
         raise NotImplementedError
 
     def write(
         self,
         result: BenchmarkResult,
-        outfile: str | os.PathLike[str] = None,
+        path: str | os.PathLike[str] = _STDOUT,
         **options: Any,
     ) -> None:
         """
@@ -63,12 +64,12 @@ class ConsoleReporter(BenchmarkReporter):
         ----------
         result: BenchmarkResult
             The benchmark result to display.
-        outfile: str | os.PathLike[str]
+        path: str | os.PathLike[str]
             For compatibility with the `BenchmarkReporter` protocol, unused.
         options: Any
             Display options used to format the resulting table.
         """
-        del outfile
+        del path
         t = Table()
 
         rows: list[list[str]] = []

--- a/src/nnbench/reporter/sqlite.py
+++ b/src/nnbench/reporter/sqlite.py
@@ -21,16 +21,16 @@ class SQLiteReporter(BenchmarkReporter):
 
     def read(
         self,
-        uri: str | os.PathLike[str],
+        path: str | os.PathLike[str],
         query: str = _DEFAULT_READ_QUERY,
         **kwargs: Any,
     ) -> list[BenchmarkResult]:
-        uri = self.strip_protocol(uri)
+        path = self.strip_protocol(path)
         # query: str | None = options.pop("query", _DEFAULT_READ_QUERY)
         if query is None:
-            raise ValueError(f"need a query to read from SQLite database {uri!r}")
+            raise ValueError(f"need a query to read from SQLite database {path!r}")
 
-        db = f"file:{uri}?mode=ro"  # open DB in read-only mode
+        db = f"file:{path}?mode=ro"  # open DB in read-only mode
         conn = sqlite3.connect(db, uri=True)
         conn.row_factory = sqlite3.Row
         cursor = conn.cursor()
@@ -42,13 +42,13 @@ class SQLiteReporter(BenchmarkReporter):
     def write(
         self,
         result: BenchmarkResult,
-        uri: str | os.PathLike[str],
+        path: str | os.PathLike[str],
         query: str = _DEFAULT_INSERT_QUERY,
         **kwargs: Any,
     ) -> None:
-        uri = self.strip_protocol(uri)
+        path = self.strip_protocol(path)
 
-        conn = sqlite3.connect(uri)
+        conn = sqlite3.connect(path)
         cursor = conn.cursor()
 
         # TODO: Guard by exists_ok state

--- a/src/nnbench/types.py
+++ b/src/nnbench/types.py
@@ -138,11 +138,11 @@ class BenchmarkResult:
 
 class BenchmarkReporter(Protocol):
     def read(
-        self, fp: str | os.PathLike[str], **kwargs: Any
+        self, path: str | os.PathLike[str], **kwargs: Any
     ) -> BenchmarkResult | list[BenchmarkResult]: ...
 
     def write(
-        self, results: BenchmarkResult, fp: str | os.PathLike[str], **kwargs: Any
+        self, result: BenchmarkResult, path: str | os.PathLike[str], **kwargs: Any
     ) -> None: ...
 
 


### PR DESCRIPTION
This fixes some fallout of the removal of iterable results from the reporter interface.

It also renames the input/output path argument to "path". Naming them differently for files (where it was "file" or "fp") and databases (where it was "uri") is technically a Liskov violation, if the arguments are not marked as positional only.