### PR TITLE
cli: Remove -P parameter display option for nnbench compare

### DIFF
--- a/docs/cli/cli.md
+++ b/docs/cli/cli.md
@@ -71,7 +71,7 @@ To create a comparison table between multiple benchmark runs, use the `nnbench c
 
 ```commandline
 $ nnbench compare -h
-usage: nnbench compare [-h] [--comparison-file <JSON>] [-P <name>] [-C <name>] [-E <name>] results [results ...]
+usage: nnbench compare [-h] [--comparison-file <JSON>] [-C <name>] [-E <name>] results [results ...]
 
 positional arguments:
   results               Results to compare. Can be given as local files or remote URIs.
@@ -80,8 +80,6 @@ options:
   -h, --help            show this help message and exit
   --comparison-file <JSON>
                         A file containing comparison functions to run on benchmarking metrics.
-  -P, --include-parameter <name>
-                        Names of input parameters to display in the comparison table.
   -C, --include-context <name>
                         Context values to display in the comparison table. Use dotted syntax for nested context values.
   -E, --extra-column <name>
@@ -156,29 +154,16 @@ $ nnbench compare result1.json result2.json
 └──────────────────┴─────┘
 ```
 
-To include benchmark parameter values in the table, use the `-P` switch (you can supply this multiple times to include multiple parameters).
-For example, to see which values were used for `a` and `b` in our `add(a, b)` benchmark above, we supply `-P a` and `-P b`:
+To include context values in the table - in our case, we might want to display the `foo` value - use the `-C` switch (you can use it multiple times to include multiple values):
 
 ```commandline
-$ nnbench compare result1.json result2.json -P a -P b
-┏━━━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
-┃ Benchmark run    ┃ add ┃ Params->a ┃ Params->b ┃
-┡━━━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
-│ nnbench-3ff188b4 │ 300 │ 200       │ 100       │
-│ nnbench-5cbb85f8 │ 300 │ 200       │ 100       │
-└──────────────────┴─────┴───────────┴───────────┘
-```
-
-To include context values in the table - in our case, we might want to display the `foo` value - use the `-C` switch (this is also appending, same as `-P`):
-
-```commandline
-$ nnbench compare result1.json result2.json -P a -P b -C foo
-┏━━━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━┓
-┃ Benchmark run    ┃ add ┃ Params->a ┃ Params->b ┃ foo ┃
-┡━━━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━┩
-│ nnbench-3ff188b4 │ 300 │ 200       │ 100       │ bar │
-│ nnbench-5cbb85f8 │ 300 │ 200       │ 100       │ baz │
-└──────────────────┴─────┴───────────┴───────────┴─────┘
+$ nnbench compare result1.json result2.json -C foo
+┏━━━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━┓
+┃ Benchmark run    ┃ add ┃ foo ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━┩
+│ nnbench-3ff188b4 │ 300 │ bar │
+│ nnbench-5cbb85f8 │ 300 │ baz │
+└──────────────────┴─────┴─────┘
 ```
 
 To learn how to define per-metric comparisons and use comparisons in a continuous training pipeline, refer to the [comparison documentation](comparisons.md).

--- a/docs/cli/comparisons.md
+++ b/docs/cli/comparisons.md
@@ -6,8 +6,7 @@ To compare benchmark results across different runs, you can use the `nnbench com
 $ nnbench compare -h
 usage: nnbench compare [-h]
                        [--comparison-file <JSON>]
-                       [-P <name>] [-C <name>]
-                       [-E <name>]
+                       [-C <name>] [-E <name>]
                        results [results ...]
 
 positional arguments:
@@ -17,8 +16,6 @@ options:
   -h, --help            show this help message and exit
   --comparison-file <JSON>
                         A file containing comparison functions to run on benchmarking metrics.
-  -P, --include-parameter <name>
-                        Names of input parameters to display in the comparison table.
   -C, --include-context <name>
                         Context values to display in the comparison table.
                         Use dotted syntax for nested context values.

--- a/src/nnbench/cli.py
+++ b/src/nnbench/cli.py
@@ -200,15 +200,6 @@ def construct_parser(config: NNBenchConfig) -> argparse.ArgumentParser:
     #     help="A file containing comparison functions to run on benchmarking metrics.",
     # )
     compare_parser.add_argument(
-        "-P",
-        "--include-parameter",
-        action="append",
-        metavar="<name>",
-        dest="parameters",
-        default=list(),
-        help="Names of input parameters to display in the comparison table.",
-    )
-    compare_parser.add_argument(
         "-C",
         "--include-context",
         action="append",
@@ -322,9 +313,7 @@ def main(argv: list[str] | None = None) -> int:
                     klass, kwargs = import_(v["class"]), v.get("kwargs", {})
                     comparators[k] = klass(**kwargs)
 
-            comp = TabularComparison(
-                results, comparators, contextvals=args.contextvals, parameters=args.parameters
-            )
+            comp = TabularComparison(results, comparators, contextvals=args.contextvals)
             comp.render()
             return int(not comp.success)
 

--- a/src/nnbench/compare.py
+++ b/src/nnbench/compare.py
@@ -115,7 +115,6 @@ class TabularComparison(AbstractComparison):
         comparators: dict[str, Comparator] | None = None,
         placeholder: str = _MISSING,
         contextvals: list[str] | None = None,
-        parameters: list[str] | None = None,
     ):
         """
         Initialize a tabular comparison class, rendering the result to a rich table.
@@ -130,11 +129,13 @@ class TabularComparison(AbstractComparison):
             unfavourable comparison.
         placeholder: str
             A placeholder string to show in the event of a missing metric.
+        contextvals: list[str] | None
+            A list of context values to display in the comparison table.
+            Supply nested context values via dotted syntax.
         """
         self.placeholder = placeholder
         self.comparators = comparators or {}
         self.contextvals = contextvals or []
-        self.parameters = parameters or []
         self.results: tuple[BenchmarkResult, ...] = tuple(collate(results))
         self.data: list[dict[str, Any]] = [make_row(rec) for rec in self.results]
         self.metrics: list[str] = []
@@ -204,7 +205,6 @@ class TabularComparison(AbstractComparison):
         # TODO: Support parameter prints
         rows: list[list[str]] = []
         columns: list[str] = ["Run Name"] + list(self.display_names.values())
-        columns += self.parameters
         columns += self.contextvals
         if has_comparable_metrics:
             columns += [_STATUS_KEY]


### PR DESCRIPTION
It's not well defined anymore, since on the command line, different benchmarks can take different values for the same argument name.